### PR TITLE
Generate random temp data set name

### DIFF
--- a/zos_concepts/data_sets/copy_edit_submit/copy_edit_submit.yml
+++ b/zos_concepts/data_sets/copy_edit_submit/copy_edit_submit.yml
@@ -29,13 +29,8 @@
 #  interact with your target, ensure you have the required authority and
 #  permissions such as writing the the target directories or creating data sets.
 #
-#  Data sets created for this sample will follow this pattern
-#  <USER>.SOME.DATA.SET where USER will be the user who submits the playbook.
-#  The user is identified by the Ansible variable `ansible_user`.
-#
-#  Additional facts for this playbook can be configured to override the defaults
-#  by reviewing the "Fact setting" section of this playbook, for example,
-#  `data_set_name` and `system_name`.
+#  Data sets created for this sample will have a randomly generated name created
+#  by the ZOAU API.
 #
 # Requirements:
 #     - IBM z/OS core collection 1.2.0 or later
@@ -52,6 +47,15 @@
 
   tasks:
     # ##########################################################################
+    # Generate a temporary data set name
+    # ##########################################################################
+    - name: Create temp data set name
+      command: "mvstmp {{ ansible_user | upper }}"
+      register: tmp_ds
+
+    - set_fact:
+        tmp_data_set: "{{ tmp_ds.stdout }}"
+    # ##########################################################################
     # Modules: zos_copy, zos_lineinfile, zos_mvs_raw, zos_job_submit
     # ##########################################################################
     # +-------------------------------------------------------------------------
@@ -63,69 +67,69 @@
     # | - Using zos_job_submit, submit both JCLs, UPTIME and PSA
     # | - Using zos_data_set, delete the copied data set on z/OS host
     # +-------------------------------------------------------------------------
-    - name: "Copy local directory {{ playbook_dir }}/files to {{ ansible_user | upper }}.SOME.DATA.SET"
+    - name: "Copy local directory {{ playbook_dir }}/files to {{ tmp_data_set }}"
       zos_copy:
         src: "{{ playbook_dir }}/files"
-        dest: "{{ ansible_user | upper }}.SOME.DATA.SET"
+        dest: "{{ tmp_data_set }}"
         encoding:
           from: ISO8859-1
           to: IBM-1047
       register: result_copy_dir
 
-    - name: "Response for copy local directory {{ playbook_dir }}/files to {{ ansible_user | upper }}.SOME.DATA.SET."
+    - name: "Response for copy local directory {{ playbook_dir }}/files to {{ tmp_data_set }}."
       debug:
         var: result_copy_dir
 
-    - name: "Copy PDS member {{ ansible_user | upper }}.SOME.DATA.SET(UPTIME) to a new PDS member {{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+    - name: "Copy PDS member {{ tmp_data_set }}(UPTIME) to a new PDS member {{ tmp_data_set }}(PSA)"
       zos_copy:
-        src: "{{ ansible_user | upper }}.SOME.DATA.SET(UPTIME)"
-        dest: "{{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+        src: "{{ tmp_data_set }}(UPTIME)"
+        dest: "{{ tmp_data_set }}(PSA)"
         remote_src: true
 
     - name: "Edit JCL PSA job card on z/OS managed node."
       zos_lineinfile:
-        src: "{{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+        src: "{{ tmp_data_set }}(PSA)"
         state: present
         regexp: "//UPTIME    JOB (T043JM,JM00,1,0,0,0),'UPTIME - JRM',"
         line: "//PSA    JOB (T043JM,JM00,1,0,0,0),'PSA - JRM',"
 
     - name: "Edit JCL PSA step-name on z/OS managed node."
       zos_lineinfile:
-        src: "{{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+        src: "{{ tmp_data_set }}(PSA)"
         state: present
         regexp: "//UPTIME  EXEC PGM=BPXBATCH"
         line: "//PSA  EXEC PGM=BPXBATCH"
 
     - name: "Edit JCL PSA USS command on z/OS managed node."
       zos_lineinfile:
-        src: "{{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+        src: "{{ tmp_data_set }}(PSA)"
         state: present
         regexp: "SH uptime"
         line: "SH ps -A"
 
-    - name: "Submit the JCL {{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+    - name: "Submit the JCL {{ tmp_data_set }}(PSA)"
       zos_job_submit:
-        src: "{{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+        src: "{{ tmp_data_set }}(PSA)"
         location: DATA_SET
         wait: true
       register: result_submit_psa
 
-    - name: "Response for submitting JCL {{ ansible_user | upper }}.SOME.DATA.SET(PSA)"
+    - name: "Response for submitting JCL {{ tmp_data_set }}(PSA)"
       debug:
         var: result_submit_psa
 
-    - name: "Submit the JCL {{ ansible_user | upper }}.SOME.DATA.SET(UPTIME)"
+    - name: "Submit the JCL {{ tmp_data_set }}(UPTIME)"
       zos_job_submit:
-        src: "{{ ansible_user | upper }}.SOME.DATA.SET(UPTIME)"
+        src: "{{ tmp_data_set }}(UPTIME)"
         location: DATA_SET
         wait: true
       register: result_submit_uptime
 
-    - name: "Response for submitting JCL {{ ansible_user | upper }}.SOME.DATA.SET(UPTIME)"
+    - name: "Response for submitting JCL {{ tmp_data_set }}(UPTIME)"
       debug:
         var: result_submit_uptime
 
-    - name: "Delete data set {{ ansible_user | upper }}.SOME.DATA.SET"
+    - name: "Delete data set {{ tmp_data_set }}"
       zos_data_set:
-        name: "{{ ansible_user | upper }}.SOME.DATA.SET"
+        name: "{{ tmp_data_set }}"
         state: absent

--- a/zos_concepts/data_sets/data_set_basics/data_set_basics.yaml
+++ b/zos_concepts/data_sets/data_set_basics/data_set_basics.yaml
@@ -29,9 +29,8 @@
 #  interact with your target, ensure you have the required authority and
 #  permissions such as writing the the target directories or creating data sets.
 #
-#  Data sets created for this sample will follow this pattern
-#  <USER>.SOME.DATA.SET where USER will be the user who submits the playbook.
-#  The user is identified by the Ansible variable `ansible_user`.
+#  Data sets created for this sample will have a randomly generated name created
+#  by the ZOAU API.
 #
 #  Additional facts for this playbook can be configured to override the defaults
 #  by reviewing the "Fact setting" section of this playbook, for example,
@@ -67,12 +66,23 @@
 
   tasks:
     # ##########################################################################
+    # Generate a temporary data set name
+    # ##########################################################################
+    - name: Create temp sequential data set name
+      command: "mvstmp {{ ansible_user | upper }}"
+      register: tmp_ds_seq
+
+    - name: Create temp sequential data set name
+      command: "mvstmp {{ ansible_user | upper }}"
+      register: tmp_ds_pds
+
+    # ##########################################################################
     # Fact setting for use by this playbook
     # ##########################################################################
     - name: Setting fact `data_set_name` for use by this sample
       set_fact:
-        data_set_name: "{{ ansible_user | upper }}.SOME.DATA.SET"
-        pds_name: "{{ ansible_user | upper }}.SOME.PDS.DATA.SET"
+        data_set_name: "{{ tmp_ds_seq.stdout }}"
+        pds_name: "{{ tmp_ds_pds.stdout }}"
 
     - name: Fact `data_set_name` set with value
       debug:

--- a/zos_concepts/data_transfer/copy_fetch_data_set/copy_fetch_data_set.yaml
+++ b/zos_concepts/data_transfer/copy_fetch_data_set/copy_fetch_data_set.yaml
@@ -30,9 +30,8 @@
 #  interact with your target, ensure you have the required authority and
 #  permissions such as writing the the target directories or creating data sets.
 #
-#  Data sets created for this sample will follow this pattern
-#  <USER>.SOME.DATA.SET where USER will be the user who submits the playbook.
-# The user is identified by the Ansible variable `ansible_user`.
+#  Data sets created for this sample will have a randomly generated name created
+#  by the ZOAU API.
 #
 #  Additional facts for this playbook can be configured to override the defaults
 #  by reviewing the "Fact setting" section of this playbook, for example,
@@ -66,11 +65,18 @@
 
   tasks:
     # ##########################################################################
+    # Generate a temporary data set name
+    # ##########################################################################
+    - name: Create temp data set name
+      command: "mvstmp {{ ansible_user | upper }}"
+      register: tmp_ds
+
+    # ##########################################################################
     # Fact setting for use by this playbook
     # ##########################################################################
     - name: Setting fact `data_set_name` for use by this sample
       set_fact:
-        data_set_name: "{{ ansible_user | upper }}.SOME.DATA.SET"
+        data_set_name: "{{ tmp_ds.stdout }}"
 
     - name: Fact `data_set_name` set with value
       debug:

--- a/zos_concepts/data_transfer/terse_fetch_data_set/terse_fetch_data_set.yml
+++ b/zos_concepts/data_transfer/terse_fetch_data_set/terse_fetch_data_set.yml
@@ -27,9 +27,8 @@
 #  interact with your target, ensure you have the required authority and
 #  permissions such as writing the the target directories or creating data sets.
 #
-#  Data sets created for this sample will follow this pattern
-#  <USER>.SOME.DATA.SET where USER will be the user who submits the playbook.
-#  The user is identified by the Ansible variable `ansible_user`.
+#  Data sets created for this sample will have a randomly generated name created
+#  by the ZOAU API.
 #
 #  Additional facts for this playbook can be configured to override the defaults
 #  by reviewing the "Fact setting" section of this playbook, for example,
@@ -48,6 +47,16 @@
   connection: ibm.ibm_zos_core.zos_ssh
 
   tasks:
+    # ##########################################################################
+    # Generate a temporary data set name
+    # ##########################################################################
+    - name: Create temp data set name
+      command: "mvstmp {{ ansible_user | upper }}"
+      register: tmp_ds
+
+    - set_fact:
+        tmp_data_set: "{{ tmp_ds.stdout }}"
+
     # ##########################################################################
     # Modules: zos_mvs_raw, zos_fetch, zos_data_set
     # ##########################################################################
@@ -72,14 +81,14 @@
       debug:
         var: temp_data_set
 
-    - name: "Terse data set {{ ansible_user | upper }}.SOME.DATA.SET to {{ temp_data_set.get('names')[0] }}"
+    - name: "Terse data set {{ tmp_data_set }} to {{ temp_data_set.get('names')[0] }}"
       zos_mvs_raw:
         program_name: amaterse
         parm: "SPACK"
         dds:
           - dd_data_set:
               dd_name: sysut1
-              data_set_name: "{{ ansible_user | upper }}.SOME.DATA.SET"
+              data_set_name: "{{ tmp_data_set }}"
               disposition: shr
           - dd_data_set:
               dd_name: sysut2
@@ -119,9 +128,9 @@
         state: absent
       when: temp_data_set is defined and temp_data_set.names|length > 0
 
-    - name: "Fetch {{ ansible_user | upper }}.SOME.DATA.SET to local machine"
+    - name: "Fetch {{ tmp_data_set }} to local machine"
       zos_fetch:
-        src: "{{ ansible_user | upper }}.SOME.DATA.SET"
+        src: "{{ tmp_data_set }}"
         dest: "{{ playbook_dir }}/"
         flat: true
         encoding:
@@ -129,11 +138,11 @@
           to: ISO8859-1
       register: result
 
-    - name: "Result of fetching {{ ansible_user | upper }}.SOME.DATA.SET to local machine"
+    - name: "Result of fetching {{ tmp_data_set }} to local machine"
       debug:
         var: result
 
-    - name: "Delete data set {{ ansible_user | upper }}.SOME.DATA.SET"
+    - name: "Delete data set {{ tmp_data_set }}"
       zos_data_set:
-        name: "{{ ansible_user | upper }}.SOME.DATA.SET"
+        name: "{{ tmp_data_set }}"
         state: absent

--- a/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
+++ b/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
@@ -30,9 +30,8 @@
 #  interact with your target, ensure you have the required authority and
 #  permissions such as writing the the target directories or creating data sets.
 #
-#  Data sets created for this sample will follow this pattern
-#  <USER>.SOME.DATA.SET where USER will be the user who submits the playbook.
-#  The user is identified by the Ansible variable `ansible_user`.
+#  Data sets created for this sample will have a randomly generated name created
+#  by the ZOAU API.
 #
 #  Additional facts for this playbook can be configured to override the defaults
 #  by reviewing the "Fact setting" section of this playbook, for example,
@@ -69,11 +68,21 @@
 
   tasks:
     # ##########################################################################
+    # Generate a temporary data set name
+    # ##########################################################################
+    - name: Create temp data set name
+      command: "mvstmp {{ ansible_user | upper }}"
+      register: tmp_ds
+
+    - set_fact:
+        tmp_data_set: "{{ tmp_ds.stdout }}"
+
+    # ##########################################################################
     # Fact setting for use by this playbook
     # ##########################################################################
     - name: Setting fact `data_set_name` for use by this sample
       set_fact:
-        data_set_name: "{{ ansible_user | upper }}.SOME.DATA.SET"
+        data_set_name: "{{ tmp_data_set }}"
 
     - name: Fact `data_set_name` set with value
       debug:


### PR DESCRIPTION
This PR addresses [NAZARE-2811](https://jsw.ibm.com/browse/NAZARE-2811), where temporary data sets used on the sample playbooks should have unique names to prevent name collisions. 