### PR TITLE
add zoau 1.1.0 support to host-setup playbook

### DIFF
--- a/zos_administration/host_setup/filter_plugins/command_paths.py
+++ b/zos_administration/host_setup/filter_plugins/command_paths.py
@@ -120,14 +120,22 @@ def filter_zoau_installs(zoau_installs, build_info, minimum_zoau_version):
     """
     for index, zoau_install in enumerate(zoau_installs):
         zoau_install["build"] = build_info[index]
-    zoau_installs.sort(key=lambda x: x.get("build"), reverse=True)
+    for zoau_install in zoau_installs:
+        zoau_install["build"] = _get_version_from_build_string(zoau_install.get("build", ""))
+    zoau_installs.sort(key=lambda x: _version_to_tuple(x.get("build")), reverse=True)
     min_version = _version_to_tuple(minimum_zoau_version)
     valid_installs = []
     for zoau_install in zoau_installs:
         if min_version <= _version_to_tuple(
-            _get_version_from_build_string(zoau_install.get("build", ""))
+            zoau_install.get("build")
         ):
             valid_installs.append(zoau_install)
+            # account for the fact 1.1.0 may or may not require pip install depending on PTF
+            if "1.1.0" in zoau_install.get("build", ""):
+                backup_install = zoau_install.copy()
+                # set build to none so we do not treat it like a pip 1.1.0 install when testing
+                backup_install["build"] = ""
+                valid_installs.append(backup_install)
     return valid_installs
 
 

--- a/zos_administration/host_setup/host_setup.yaml
+++ b/zos_administration/host_setup/host_setup.yaml
@@ -170,6 +170,7 @@
         python_root: "{{ chosen_python.get('root') }}"
         python_interpreter: "{{ chosen_python.get('interpreter') }}"
         zoau_root: "{{ chosen_zoau.get('root') }}"
+        is_110: "{{ True if '1.1.0' in chosen_zoau.get('build') else False }}"
       delegate_to: localhost
 
     - set_fact:
@@ -192,5 +193,5 @@
         var: potential_paths
 
     - debug:
-        msg: "Inventory file placed at '{{ playbook_dir }}/{{ inventory_hostname_short }}', 
+        msg: "Inventory file placed at '{{ playbook_dir }}/{{ inventory_hostname_short }}',
         host_vars file placed at '{{ playbook_dir }}/host_vars/{{ inventory_hostname_short }}.yaml'"

--- a/zos_administration/host_setup/tasks/choose_zoau.yml
+++ b/zos_administration/host_setup/tasks/choose_zoau.yml
@@ -36,6 +36,9 @@
       register: tempfile_1
       delegate_to: localhost
 
+    - debug:
+        var: item
+
     - name: Write to temporary file
       template:
         src: "{{ playbook_dir }}/templates/test-vars.j2"
@@ -44,6 +47,7 @@
         python_root: "{{ chosen_python.get('root') }}"
         python_interpreter: "{{ chosen_python.get('interpreter') }}"
         zoau_root: "{{ item.get('root') }}"
+        is_110: "{{ True if '1.1.0' in item.get('build') else False }}"
       delegate_to: localhost
 
     - name: Load variables from temp file

--- a/zos_administration/host_setup/templates/host_vars.j2
+++ b/zos_administration/host_setup/templates/host_vars.j2
@@ -15,7 +15,13 @@ ZOAU: "{{ zoau_root }}"
 environment_vars:
   _BPXK_AUTOCVT: "ON"
   ZOAU_HOME: "{{ ZOAU }}"
+{% endraw %}
+{% if not is_110 %}
+{% raw %}
   PYTHONPATH: "{{ ZOAU }}/lib"
+{% endraw %}
+{% endif %}
+{% raw %}
   LIBPATH: "{{ ZOAU }}/lib:{{ PYZ }}/lib:/lib:/usr/lib:."
   PATH: "{{ ZOAU }}/bin:{{ PYZ }}/bin:/bin:/usr/sbin:/var/bin"
   _CEE_RUNOPTS: "FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"

--- a/zos_administration/host_setup/templates/test-vars.j2
+++ b/zos_administration/host_setup/templates/test-vars.j2
@@ -7,7 +7,9 @@
 environment_vars:
   _BPXK_AUTOCVT: "ON"
   ZOAU_HOME: "{{ zoau_root }}"
+{% if not is_110 %}
   PYTHONPATH: "{{ zoau_root }}/lib"
+{% endif %}
   LIBPATH: "{{ zoau_root }}/lib:{{ python_root }}/lib:/lib:/usr/lib:."
   PATH: "{{ zoau_root }}/bin:{{ python_root }}/bin:/bin:/usr/sbin:/var/bin"
   _CEE_RUNOPTS: "FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"


### PR DESCRIPTION
This PR adds logic to the host-setup playbook to address the special installation requirements of ZOAU 1.1.0, additional changes should (hopefully) not be required for newer versions.