### PR TITLE
Bugfix wto reply, change from cancel to end

### DIFF
--- a/zos_concepts/zos_operator/zos_operator_basics/zos_operator_basics.yaml
+++ b/zos_concepts/zos_operator/zos_operator_basics/zos_operator_basics.yaml
@@ -7,6 +7,8 @@
 #
 # [1.0.0] - 2020-09-01
 #  - Released initial version
+# [1.3.0-beta.2] - 2021-03-11
+# - Bugfix WTO reply from cancel to end
 ###############################################################################
 
 ###############################################################################
@@ -144,21 +146,21 @@
         msg: "{{ filtered_zos_operator_action_query }}"
       when: bool_zos_operator_action_continue and filtered_zos_operator_action_query is defined
 
-    - name: Set cancel value if there is one matching actionable message
+    - name: Set reply value if there is one matching actionable message
       set_fact:
-        cancel_num: "{{ result_zos_operator_action_query.actions[0].number }}"
+        reply_num: "{{ result_zos_operator_action_query.actions[0].number }}"
       when: bool_zos_operator_action_continue and filtered_zos_operator_action_query is defined and  (filtered_zos_operator_action_query | length == 1)
 
-    - name: Reply to operator action with "cancel"
+    - name: Reply to operator action with "end"
       zos_operator:
-        cmd: "{{ cancel_num}}cancel"
-      register: result_zos_operator_cancel
-      when: bool_zos_operator_action_continue and cancel_num is defined
+        cmd: "{{ reply_num}}end"
+      register: result_zos_operator_end
+      when: bool_zos_operator_action_continue and reply_num is defined
 
     - name: Response for reply to operator action with "cancel"
       debug:
-        msg: "{{ result_zos_operator_cancel }}"
-      when: bool_zos_operator_action_continue and result_zos_operator_cancel is defined and cancel_num is defined
+        msg: "{{ result_zos_operator_end }}"
+      when: bool_zos_operator_action_continue and result_zos_operator_end is defined and reply_num is defined
 
     - name: Verify actionable message on system {{ system_name }} is canceled
       zos_operator_action_query:


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>
This changes and corrects the WTO response used. Technically there is no such reply `cancel` , the correct response would be `end` and then a clean up routine to remove the temporary data set. This fix only addresses the change to use `end`. A separate change will be done to clean up the temporary data set as its not currently logic in this flow. 

Playbook output:
```
ddimatos:[ ~/git/github/playbooks ]ansible-playbook -i inventory zos_operator_basics.yaml

PLAY [zvm] **************************************************************************************************************************************************************

TASK [Detecting system name] ********************************************************************************************************************************************
changed: [zvm]

TASK [Setting fact `system_name` for use by this sample] ****************************************************************************************************************
ok: [zvm]

TASK [Fact `system_name` set with value] ********************************************************************************************************************************
ok: [zvm] => {
    "msg": "EC33017A"
}

TASK [Query actionable messages on system EC33017A] *********************************************************************************************************************
ok: [zvm]

TASK [Response for query actionable messages on system EC33017A] ********************************************************************************************************
ok: [zvm] => {
    "msg": {
        "actions": [],
        "changed": false,
        "failed": false
    }
}

TASK [Filter actionable messages that match 'IEE094D SPECIFY OPERAND', if more than one is found this demo will skip the operator task.] ********************************
ok: [zvm]

TASK [Evaluate if there are any existing dump messages matching 'IEE094D SPECIFY OPERAND'] ******************************************************************************
ok: [zvm] => {
    "changed": false,
    "msg": "Operator demo will continue, no matching 'IEE094D SPECIFY OPERAND' actions were discovered."
}

TASK [Create an operator action (WTOR) "DUMP COMM=('test dump')" for system EC33017A] ***********************************************************************************
changed: [zvm]

TASK [Response for create an operator action (WTOR) "DUMP COMM=('test dump')" for system EC33017A] **********************************************************************
ok: [zvm] => {
    "msg": {
        "changed": true,
        "content": [
            "EC33017A  2021070  10:26:16.00             ISF031I CONSOLE OMVSADM ACTIVATED",
            "EC33017A  2021070  10:26:16.00            -DUMP COMM=( TEST DUMP )",
            "EC33017A  2021070  10:26:16.01            *09 IEE094D SPECIFY OPERAND(S) FOR DUMP COMMAND",
            "",
            "",
            "Ran 0 \"DUMP COMM=('test dump')\" QUIET WAIT"
        ],
        "failed": false,
        "rc": 0
    }
}

TASK [Query actionable messages on system EC33017A] *********************************************************************************************************************
ok: [zvm]

TASK [Response for query actionable messages on system EC33017A] ********************************************************************************************************
ok: [zvm] => {
    "msg": {
        "actions": [
            {
                "job_name": null,
                "message_id": "IEE094D",
                "message_text": "IEE094D SPECIFY OPERAND(S) FOR DUMP",
                "number": "09",
                "system": "EC33017A",
                "type": "R"
            }
        ],
        "changed": false,
        "count": 1,
        "failed": false
    }
}

TASK [Filter actionable messages that match only 'DUMP'] ****************************************************************************************************************
ok: [zvm]

TASK [Response for filter actionable messages that match only 'DUMP'] ***************************************************************************************************
ok: [zvm] => {
    "msg": [
        {
            "job_name": null,
            "message_id": "IEE094D",
            "message_text": "IEE094D SPECIFY OPERAND(S) FOR DUMP",
            "number": "09",
            "system": "EC33017A",
            "type": "R"
        }
    ]
}

TASK [Set reply value if there is one matching actionable message] ******************************************************************************************************
ok: [zvm]

TASK [Reply to operator action with "end"] ******************************************************************************************************************************
changed: [zvm]

TASK [Response for reply to operator action with "cancel"] **************************************************************************************************************
ok: [zvm] => {
    "msg": {
        "changed": true,
        "content": [
            "EC33017A  2021070  10:26:25.32             ISF031I CONSOLE OMVSADM ACTIVATED",
            "EC33017A  2021070  10:26:25.32            -09end",
            "EC33017A  2021070  10:26:25.32             IEE600I REPLY TO 09 IS;END",
            "",
            "",
            "Ran 0 \"09end\" QUIET WAIT"
        ],
        "failed": false,
        "rc": 0
    }
}

TASK [Verify actionable message on system EC33017A is canceled] *********************************************************************************************************
ok: [zvm]

TASK [Verify no actionable messages match 'IEE094D SPECIFY OPERAND' with filter] ****************************************************************************************
ok: [zvm]

TASK [Response for verifying actionable messages on system EC33017A are canceled] ***************************************************************************************
ok: [zvm] => {
    "changed": false,
    "msg": "All actionable messages that match 'IEE094D SPECIFY OPERAND' have been cancelled"
}

PLAY RECAP **************************************************************************************************************************************************************
zvm                        : ok=19   changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```