### PR TITLE
Add README for CICS collection samples

### DIFF
--- a/cics/README.md
+++ b/cics/README.md
@@ -1,0 +1,25 @@
+# Samples for the IBM z/OS CICS collection
+
+[Documentation site](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_cics/docs/ansible_content.html) | [CICS collection on Galaxy](https://galaxy.ansible.com/ibm/ibm_zos_cics) | [CICS collection on Automation Hub](https://cloud.redhat.com/ansible/automation-hub/repo/published/ibm/ibm_zos_cics)
+
+This repository provides a number of samples that show how to use the CICS collection for real-life use cases:
+
+1. [Retrieving operational data from running CICS regions](cmci/reporting)
+
+    The `reporting` sample gives a good overview of how to get started with the tasks provided by the CICS collection.
+    
+    This sample shows how to retrieve data from running CICS regions and format it for use in dashboarding or ad hoc analysis.
+
+    Because this sample only uses the HTTP-based CMCI REST API, it can easily be run from a workstation rather than needing any setup on z/OS.
+
+1. [Deploying a program to a CICS region](cmci/deploy_program)
+
+    The `deploy_program` sample shows how you can copy a load module from a build data set to a library used by CICS, and then NEWCOPY the program in CICS.
+
+    This sample uses the z/OS core collection in concert with the CICS collection, within the one playbook.
+
+1. [Customising when a CMCI module should fail](cmci/override_failure)
+
+    The `override_failure` sample shows how to override the default error when searching for a program that doesn't exist in CICS.
+
+    The tasks provided by the CICS collection have automatic awareness of failure criteria, such as HTTP errors or actions being applied but zero resources matching the criteria. However, sometimes you want to override that behaviour and carry on despite a failure, as this sample shows.

--- a/cics/cmci/deploy_program/README.md
+++ b/cics/cmci/deploy_program/README.md
@@ -3,8 +3,8 @@
 This sample playbook demonstrates how to use the `zos_copy` module from the `ibm_zos_core` collection in
 conjunction with the `cmci_action` module from the `ibm_zos_cics` collection.
 
-This sample shows how to use these modules to deploy a load module from a build output dataset to a CICS
-load library, and `NEWCOPY` the `PROGRAM` in CICS.
+This sample shows how to use these modules to deploy a load module from a build output data set to a CICS
+library, and `NEWCOPY` the `PROGRAM` in CICS.
 
 This sample additionally shows how to automate installation of pre-requisites for the `cmci_*` modules.
 
@@ -70,7 +70,7 @@ scope: MYRGN
 # Name of the target program
 program: PRG1
 
-# Name of the dataset containing the build output load module
+# Name of the data set containing the build output load module
 build_ds: BLD.OUTPUT
 
 # Name of the destination load library for the load module
@@ -89,6 +89,10 @@ cmci_password:
 ansible-playbook -i inventory.yml deploy_program.yml
 ```
 
+## What next?
+
+- Look at the [other samples](../..) to find examples of what else you can do with the CICS collection.
+
 # Copyright
 
 © Copyright IBM Corporation 2021
@@ -102,3 +106,5 @@ Version 2.0](https://opensource.org/licenses/Apache-2.0).
 
 Please refer to the [support section](../../../README.md#support) for more
 details.
+
+#

--- a/cics/cmci/deploy_program/host_vars/zos_host.yml
+++ b/cics/cmci/deploy_program/host_vars/zos_host.yml
@@ -40,7 +40,7 @@ scope: MYRGN
 # Name of the target program
 program: PRG1
 
-# Name of the dataset containing the build output load module
+# Name of the data set containing the build output load module
 build_ds: BLD.OUTPUT
 
 # Name of the destination load library for the load module

--- a/cics/cmci/override_failure/README.md
+++ b/cics/cmci/override_failure/README.md
@@ -87,6 +87,10 @@ payload to determine whether the module has failed. By specifying that
 `cpsm_response` codes of both `OK` and `NODATA` are OK, the playbook ignores
 failures due to finding no programs.
 
+## What next?
+
+- Look at the [other samples](../..) to find examples of what else you can do with the CICS collection.
+
 # Support
 
 Please refer to the [support section](../../../README.md#support) for more

--- a/cics/cmci/reporting/README.md
+++ b/cics/cmci/reporting/README.md
@@ -89,6 +89,8 @@ the results of the report.
   available CMCI resource names at
   [CMCI resource names](https://www.ibm.com/support/knowledgecenter/SSGMCP_5.6.0/reference-system-programming/cmci/clientapi_resources.html).
 
+- Look at the [other samples](../..) to find examples of what else you can do with the CICS collection.
+
 # Copyright
 
 © Copyright IBM Corporation 2021


### PR DESCRIPTION
Added a top-level README for the CICS collection samples, to list out the available samples and give them a proposed ordering.

Also a couple of tweaks for terminology.