### PR TITLE
Add CICS topics to the top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ this is outlined in the
 * [z/OS Administration](zos_administration/)
    * [Set Up Host Vars by Configuring Python and ZOAU Installation](zos_administration/host_setup)
 
+* [CICS samples](cics/)
+   * [Retrieve operational data from running CICS regions](cics/cmci/reporting/)
+   * [Deploy a program to a CICS region](cics/cmci/deploy_program/)
+   * [Customize when a CMCI module should fail](cics/cmci/override_failure/)
+
 ## Blogs
 
 * [Job Submission on z/OS Made Easy with Ansible](https://community.ibm.com/community/user/ibmz-and-linuxone/blogs/asif-mahmud1/2020/06/10/job-submission-on-zos-made-easy-with-ansible) - \[[Sample playbook](zos_concepts/jobs/submit_query_retrieve)\]

--- a/cics/README.md
+++ b/cics/README.md
@@ -18,7 +18,7 @@ This repository provides a number of samples that show how to use the CICS colle
 
     This sample uses the z/OS core collection in concert with the CICS collection, within the one playbook.
 
-1. [Customising when a CMCI module should fail](cmci/override_failure)
+1. [Customizing when a CMCI module should fail](cmci/override_failure)
 
     The `override_failure` sample shows how to override the default error when searching for a program that doesn't exist in CICS.
 

--- a/cics/cmci/override_failure/README.md
+++ b/cics/cmci/override_failure/README.md
@@ -1,4 +1,4 @@
-# Customising when a CMCI module should fail
+# Customizing when a CMCI module should fail
 
 This sample playbook demonstrates how to override the default failure criteria
 of the CMCI modules.


### PR DESCRIPTION
This PR adds the CICS samples to the front page, to make it more evident that they exist.

@ddimatos I'd be glad to get your view on this - this feels like one of the first non-core collections on the front page. How does the layout look?