### PR TITLE
Update filters with added python source code encoding for xc2 error

### DIFF
--- a/zos_administration/host_setup/filter_plugins/command_paths.py
+++ b/zos_administration/host_setup/filter_plugins/command_paths.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 ###############################################################################
 # © Copyright IBM Corporation 2020
 # Contributed and supported by the Ansible Content for IBM Z Team

--- a/zos_administration/host_setup/filter_plugins/command_strings.py
+++ b/zos_administration/host_setup/filter_plugins/command_strings.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 ###############################################################################
 # © Copyright IBM Corporation 2020
 # Contributed and supported by the Ansible Content for IBM Z Team


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

Both filters below did not have an encoding defined in the Python source which on my system threw a "Non-ASCII character '\xc2' in file error". 
This should correct both plugins:
 - /host_setup/filter_plugins/command_paths.py
 - zos_administration/host_setup/filter_plugins/command_strings.py