### PR TITLE
Refer to the main repo README in the CICS README

### DIFF
--- a/zos_subsystems/cics/README.md
+++ b/zos_subsystems/cics/README.md
@@ -23,3 +23,7 @@ This repository provides a number of samples that show how to use the CICS colle
     The `override_failure` sample shows how to override the default error when searching for a program that doesn't exist in CICS.
 
     The tasks provided by the CICS collection have automatic awareness of failure criteria, such as HTTP errors or actions being applied but zero resources matching the criteria. However, sometimes you want to override that behaviour and carry on despite a failure, as this sample shows.
+
+---
+
+These CICS samples are just some of the samples available for the Red Hat Ansible Certified Content for IBM Z. You can find samples covering other aspects at the [root of the repository](https://github.com/IBM/z_ansible_collections_samples).


### PR DESCRIPTION
This adds a reference to the root README, useful for those who have been pointed directly at the CICS README.