### PR TITLE
Fix issue 6534 - Use existing network

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
@@ -65,7 +65,7 @@
   - name: 'Create the Compute servers'
     os_server:
       name: "{{ os_compute_server_name }}-{{ compute_nodes_json.compute_node_names[-1] }}"
-      image: "{{ os_image_rhcos }}"
+      image: "rhcos"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
       timeout: 2400

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-bastion.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-bastion.yaml
@@ -1,5 +1,5 @@
 # =================================================================
-# Copyright 2021 https://github.com/openshift/installer
+# Copyright 2021 https://github.com/multi-arch/multiarch-ci-playbooks
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# =================================================================
+# =================================================================.
 
 # =================================================================
 # Licensed Materials - Property of IBM
@@ -24,28 +24,9 @@
 # =================================================================
 #
 # Change Summary: 
-# - Move port creation to network.yaml
-# - Delete unnecessary Ansible tasks
-# - Add server creation timeout
+# - Add more playbooks
 
-# Required Python packages:
-#
-# ansible
-# openstackclient
-# openstacksdk
-# netaddr
-
-- name: 'Import common yaml'
-  import_tasks: common.yaml
-
-- name: 'Create the bootstrap server'
-  os_server:
-    name: "{{ os_bootstrap_server_name }}"
-    image: "rhcos"
-    flavor: "{{ os_flavor_master }}"
-    userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
-    timeout: 3600
-    auto_ip: no
-    nics:
-    - port-name: "{{ os_port_bootstrap }}"
-    meta: "{{ cluster_id_tag }}"
+---
+- import_playbook: configure-bastion-properties.yaml
+- import_playbook: configure-dns.yaml
+- import_playbook: configure-haproxy.yaml

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-network-existing.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-network-existing.yaml
@@ -1,0 +1,14 @@
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+---
+- name: Configure existing network
+  hosts: localhost
+  roles:
+  - configure-network-existing

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -35,10 +35,14 @@ all:
       ansible_python_interpreter: "{{ansible_playbook_python}}"
 
       # User-provided values
-      vm_type: 'zvm'
+      vm_type: 'kvm'
       disk_type: 'dasd'
       openshift_version: '4.7'
-      openshift_minor_version: '0'
+      openshift_minor_version: '7'
+
+      # Support to use existing network
+      use_existing_network_name: 'flat01'
+      use_existing_network_subnet: 'a2134ea5-7c7c-4515-8cbe-71fd41686935'  #f9921330-0cc0-419a-a055-d202f1fb11d9
 
       # The auto_allocated_ip default value is true, then IPs will be allocated from subnet range. 
       # If you need specify IP addresses, set auto_allocated_ip to false.
@@ -48,9 +52,8 @@ all:
       # The allocation pool can be configured by allocation_pool_start and allocation_pool_end
       # allocation_pool_start: '172.26.0.2'
       # allocation_pool_end: '172.26.0.10'
-      os_flavor_master: 'medium'
-      os_flavor_worker: 'large'
-      os_image_rhcos: 'rhcos'
+      os_flavor_master: 'ocp'
+      os_flavor_worker: 'ocp'
 
       # Name of the SDN.
       os_networking_type: 'OpenshiftSDN'
@@ -65,23 +68,20 @@ all:
 
     # Bastion DNS and HAProxy settings
     bastion:
-      ansible_ssh_host: 172.26.103.100
-      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
-
       # Configure the IP address of your private subnet
       # These default values will work by default
       # with the default configuration defined in
       # tony-hypervisor-setup
-      bastion_private_ip_address: 172.26.103.100
+      bastion_private_ip_address: 172.26.105.35
       gateway_ip: 172.26.0.1
-      bastion_subnet_prefix_reverse: 103.26.172
+      bastion_subnet_prefix_reverse: 105.26.172
       # The queries from IPs in `cluster_subnet_range` will be allowed, 
       # we suggest setting `cluster_subnet_range` the same as localhost's `os_subnet_range`
       cluster_subnet_range: 172.26.0.0/16
       bastion_public_ip_address: "{{ ansible_default_ipv4.address }}"
   
   vars:
-    os_dns_domain: "172.26.103.100"
+    os_dns_domain: "172.26.105.35"
     cluster_domain_name: "openshift.example.com"
     
     # If you need specify IP addresses (the auto_allocated_ip value is false), fill below lists.

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
@@ -50,7 +50,7 @@
 - name: 'Create the Compute servers'
   os_server:
     name: "{{ os_compute_server_name }}-{{ item.1 }}"
-    image: "{{ os_image_rhcos }}"
+    image: "rhcos"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     timeout: 2400

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -69,7 +69,7 @@
 - name: 'Create the Control Plane servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "{{ os_image_rhcos }}"
+    image: "rhcos"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     timeout: 2400

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
@@ -19,7 +19,7 @@
   register: infra_id
 
 - name: Edit Bootstrap Ignition
-  script: tools/ignition-modify.py
+  script: tools/ignition-modify.py 
   args:
     executable: python3
 
@@ -42,4 +42,5 @@
     executable: python3
 
 - name: Generate Master Ignition
-  script: tools/generate-master-ignition.sh {{ infra_id.stdout_lines[0] }}
+  script: tools/generate-master-ignition.py {{ infra_id.stdout_lines[0] }} 
+

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
@@ -1,0 +1,155 @@
+# =================================================================
+# Copyright 2021 https://github.com/openshift/installer
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =================================================================
+
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+#
+# Change Summary: 
+# - Add port creation
+# - Delete unnecessary Ansible tasks
+# - Use random strings to name compute ports
+
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+
+- name: 'Import common yaml'
+  import_tasks: common.yaml
+
+- name: 'Check existing netowrk name is properly set'
+  fail:
+    msg: "use_existing_network_name is not defined!"
+  failed_when: use_existing_network_name is not defined
+
+- name: 'Check existing netowrk subnet is properly set'
+  fail:
+    msg: "use_existing_network_subnet is not defined!"
+  failed_when: use_existing_network_subnet is not defined
+
+- name: 'Update subnet {{ use_existing_network_subnet }} DNS name server'
+  command:
+    cmd: "openstack subnet set --dns-nameserver {{ vars.os_dns_domain }} {{ use_existing_network_subnet }}"
+
+- name: 'Update subnet {{ use_existing_network_subnet }} allocation pools'
+  command:
+    cmd: "openstack subnet set --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} {{ use_existing_network_subnet }}"
+  when:
+  - allocation_pool_start is defined
+  - allocation_pool_end is defined 
+
+- name: 'Export Infra ID'
+  shell:
+    cmd: "jq -r .infraID metadata.json"
+  register: infra_id
+
+- name: 'Generate random string for the Compute ports and store them in a json file'
+  script: tools/generate-random-compute-json.py {{ infra_id.stdout_lines[0] }} {{ os_compute_nodes_number }}
+  args:
+    executable: python3
+
+- name: 'Read compute nodes names'
+  set_fact:
+    compute_nodes_json: "{{ lookup('file', '.compute-nodes-{{ infra_id.stdout_lines[0] }}.json') | from_json }}"
+
+- name: 'Create the bootstrap server port'
+  os_port:
+    name: "{{ os_port_bootstrap }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+    fixed_ips:
+    - subnet: "{{ os_subnet }}"
+      ip_address: "{{ os_bootstrap_ip }}"
+  when:
+  - auto_allocated_ip == false
+
+- name: 'Create the Control Plane ports'
+  os_port:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+    fixed_ips:
+    - subnet: "{{ os_subnet }}"
+      ip_address: "{{ os_master_ip[item.0] }}"
+  with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+  when:
+  - auto_allocated_ip == false
+
+- name: 'Create the Compute ports'
+  os_port:
+    name: "{{ os_port_worker }}-{{ item.1 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_worker }}"
+    fixed_ips:
+    - subnet: "{{ os_subnet }}"
+      ip_address: "{{ os_infra_ip[item.0]}}"
+  with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"
+  when:
+  - auto_allocated_ip == false
+
+- name: 'Create the bootstrap server port'
+  os_port:
+    name: "{{ os_port_bootstrap }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+  when:
+  - auto_allocated_ip == true
+
+
+- name: 'Create the Control Plane ports'
+  os_port:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+  with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+  when:
+  - auto_allocated_ip == true
+
+- name: 'Create the Compute ports'
+  os_port:
+    name: "{{ os_port_worker }}-{{ item.1 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_worker }}"
+  with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"
+  when:
+  - auto_allocated_ip == true
+    
+- name: 'Set bootstrap port tag'
+  command:
+    cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_bootstrap }}"
+
+- name: 'Set Control Plane ports tag'
+  command:
+    cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
+  with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+
+- name: 'Set Compute ports tag'
+  command:
+    cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_worker }}-{{ item.1 }}"
+  with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-worker-ignition.py
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-worker-ignition.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+import base64
+import json
+import os
+import sys
+
+infra_id = sys.argv[1]
+dns = sys.argv[2]
+
+with open('worker.ign', 'r') as f:
+    worker_ignition = json.load(f)
+
+for i in range(0, 3):
+    ignition = worker_ignition.copy()
+    hostname = '%s-worker-%s' % (infra_id, i)
+    files = []
+    if 'storage' in ignition:
+        files = ignition['storage'].get('files', [])
+    files.append(
+        {
+            'path': '/etc/hostname',
+            'mode': 420,
+            'contents': {
+                'source': 'data:text/plain;charset=utf-8;base64,' +
+                base64.standard_b64encode(hostname.encode()).decode().strip(),
+                'verification': {}
+            },
+            'filesystem': 'root'
+        }
+    )
+    if 'storage' not in ignition:
+        ignition['storage'] = dict()
+    ignition['storage']['files'] = files
+
+    with open('%s-ignition.json' % hostname, 'w') as f:
+        json.dump(ignition, f)


### PR DESCRIPTION
1) Update inventory.yaml with existing network
test scenario:
1.1) Failed when the user does not specify `use_existing_network_name`
1.2) Failed when the user does not specify `use_existing_network_subnet `
1.3) Update allocation pool when the user gives `allocation_pool_start` and `allocation_pool_end`
2) Update Readme, and add HAProxy record when user want to use own DNS and HAProxy.