### PR TITLE
Fix ocp 6534 - Use existing network to deploy OCP UPI

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -220,7 +220,7 @@ The ansible playbooks has automated origin complex UPI mannul process, such as c
 
 ### Config HAproxy and DNS on a bastion node (default)
 
-User can choose to use your own bastion node to deploy cluster. If there aren't DNS server and Haproxy on bastion node, highly recommend installing them by ansible playbook [Configure Bastion](#configure-bastion), or you have an external DNS server which is managed in other DNS provider, if so, you need to add openshift recorder in your DNS server manually, please see the following [example](#sample-dns-zone-database) to add it.
+User can choose to use your own bastion node to deploy cluster. If there aren't DNS server and Haproxy on bastion node, highly recommend installing them by ansible playbook [Configure Bastion](#configure-bastion), or you have an external DNS server which is managed in other DNS provider, if so, you need to add openshift recorder in your DNS server and HAProxy manually, please see the following [example](#sample-dns-zone-database) to add it.
 
 #### Sample DNS zone database
 ```
@@ -246,7 +246,73 @@ master-2              IN A 172.26.103.233
 worker-62c41              IN A 172.26.103.234
 worker-a7c60              IN A 172.26.103.235
 worker-c94d1              IN A 172.26.103.236
+
+etcd-0              IN A 172.26.103.231
+etcd-1              IN A 172.26.103.232
+etcd-2              IN A 172.26.103.233
+
+_etcd-server-ssl._tcp IN SRV 0 10 2380 etcd-0.openshift.example.com.
+                      IN SRV 0 10 2380 etcd-1.openshift.example.com.
+                      IN SRV 0 10 2380 etcd-2.openshift.example.com.
 ```
+
+#### Sample HAProxy 
+```
+frontend ocp4-kubernetes-api-server
+   mode tcp
+   option tcplog
+   bind api.openshift.example.com:6443
+   bind api-int.openshift.example.com:6443
+   default_backend ocp4-kubernetes-api-server
+
+frontend ocp4-machine-config-server
+   mode tcp
+   option tcplog
+   bind api.openshift.example.com:22623
+   bind api-int.openshift.example.com:22623
+   default_backend ocp4-machine-config-server
+
+frontend ocp4-router-http
+   mode tcp
+   option tcplog
+   bind apps.openshift.example.com:80
+   default_backend ocp4-router-http
+
+frontend ocp4-router-https
+   mode tcp
+   option tcplog
+   bind apps.openshift.example.com:443
+   default_backend ocp4-router-https
+
+backend ocp4-kubernetes-api-server
+   mode tcp
+   balance source
+   server bootstrap bootstrap.openshift.example.com:6443 check
+   server master-0 master-0.openshift.example.com:6443 check
+   server master-1 master-1.openshift.example.com:6443 check
+   server master-2 master-2.openshift.example.com:6443 check
+
+backend ocp4-machine-config-server
+   mode tcp
+   balance source
+   server bootstrap bootstrap.openshift.example.com:22623 check
+   server master-0 master-0.openshift.example.com:22623 check
+   server master-1 master-1.openshift.example.com:22623 check
+   server master-2 master-2.openshift.example.com:22623 check
+
+backend ocp4-router-http
+   mode tcp
+         server worker-62c41 worker-62c41.openshift.example.com:80 check
+         server worker-a7c60 worker-a7c60.openshift.example.com:80 check
+         server worker-c94d1 worker-c94d1.openshift.example.com:80 check
+
+backend ocp4-router-https
+   mode tcp
+         server worker-62c41 worker-62c41.openshift.example.com:443 check
+         server worker-a7c60 worker-a7c60.openshift.example.com:443 check
+         server worker-c94d1 worker-c94d1.openshift.example.com:443 check
+```
+
 #### Verify DNS record
 
 You can use the nslookup <hostname> command to verify name resolution. 
@@ -282,6 +348,7 @@ Update bastion node info, dns domain and OCP nodes IP addresses in `inventory.ya
     os_dns_domain: "172.26.103.100"
     cluster_domain_name: "openshift.example.com"
 ```
+
 
 ### Modify other user-provided values in inventory.yaml
 
@@ -372,20 +439,7 @@ The playbook creates one Security group for the Control Plane and one for the Co
 ```sh
 $ ansible-playbook -i inventory.yaml configure-network.yaml
 ```
-
-The playbook creates a default VLAN network and a subnet. The subnet obeys `os_subnet_range`. By default, if the `os_subnet_range` is '172.26.0.0/16', the allocation pools will be '172.26.0.10-172.26.255.254'. The allocation pool can be configured by `allocation_pool_start` and `allocation_pool_end`. Finally, the playbook creates the nodes' ports. 
-
-***Note***: If your Bastion node was not VLAN network type, the bootstrap node should be connected confused with bastion node. Please use of existing network.
-
-
-**Use existing network**
-
-If you want to use an existing netowrk instead of creating a new network, you can specify the 
-network name and subnet UUID, for example:
-
-```
-$ ansible-playbook -i inventory.yaml configure-network.yaml -e os_network="<Network_name>" -e os_subnet="<Network_subnet>"
-```
+The playbook use an existing network to deploy OCP, so it will overwrite DNS nameserver of this network card, please attention other application will not be interrupted.
 
 ### Configure bastion
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -220,7 +220,7 @@ The ansible playbooks has automated origin complex UPI mannul process, such as c
 
 ### Config HAproxy and DNS on a bastion node (default)
 
-User can choose to use your own bastion node to deploy cluster. If there aren't DNS server and Haproxy on bastion node, highly recommend installing them by ansible playbook [Configure Bastion](#configure-bastion), or you have an external DNS server which is managed in other DNS provider, if so, you need to add openshift recorder in your DNS server and HAProxy manually, please see the following [example](#sample-dns-zone-database) to add it.
+User can choose to use your own bastion node to deploy cluster. If there aren't DNS server and Haproxy on bastion node, highly recommend installing them by ansible playbook [Configure Bastion](#configure-bastion), or you have an external DNS server which is managed in other DNS provider, if so, you need to add openshift recorder in your DNS server and Load Balancer manually, please see the following [example](#sample-dns-zone-database) to add it.
 
 #### Sample DNS zone database
 ```
@@ -439,7 +439,7 @@ The playbook creates one Security group for the Control Plane and one for the Co
 ```sh
 $ ansible-playbook -i inventory.yaml configure-network.yaml
 ```
-The playbook use an existing network to deploy OCP, so it will overwrite DNS nameserver of this network card, please attention other application will not be interrupted.
+The playbook use an existing network to deploy OCP, so it will overwrite DNS nameserver of this network.
 
 ### Configure bastion
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-network.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-network.yaml
@@ -8,7 +8,7 @@
 # =================================================================
 
 ---
-- name: Configure network
+- name: Configure existing network
   hosts: localhost
   roles:
-  - configure-network
+  - configure-network-existing

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -34,10 +34,9 @@ all:
       ansible_connection: local
       ansible_python_interpreter: "{{ansible_playbook_python}}"
 
-      # To succeed deploy OCP, we will overwrite DNS nameserver on existing network
-      # Please be careful other application will not be interrupted.
+      # To succeed deploy OCP, it will overwrite DNS nameserver of this network.
       use_existing_network_name: 'flat01'
-      use_existing_network_subnet: 'a2134ea5-7c7c-4515-8cbe-71fd41686935'  #f9921330-0cc0-419a-a055-d202f1fb11d9
+      use_existing_network_subnet: 'a2134ea5-7c7c-4515-8cbe-71fd41686935' 
 
       # User-provided values
       vm_type: 'zvm'
@@ -89,6 +88,7 @@ all:
       bastion_public_ip_address: "{{ ansible_default_ipv4.address }}"
   
   vars:
+    # If you want to use your external DNS server, set os_dns_domain to use it.
     os_dns_domain: "172.26.103.100"
     cluster_domain_name: "openshift.example.com"
     

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -34,6 +34,11 @@ all:
       ansible_connection: local
       ansible_python_interpreter: "{{ansible_playbook_python}}"
 
+      # To succeed deploy OCP, we will overwrite DNS nameserver on existing network
+      # Please be careful other application will not be interrupted.
+      use_existing_network_name: 'flat01'
+      use_existing_network_subnet: 'a2134ea5-7c7c-4515-8cbe-71fd41686935'  #f9921330-0cc0-419a-a055-d202f1fb11d9
+
       # User-provided values
       vm_type: 'zvm'
       disk_type: 'dasd'

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
@@ -47,13 +47,26 @@
     msg: "use_existing_network_subnet is not defined!"
   failed_when: use_existing_network_subnet is not defined
 
-- name: 'Update subnet {{ use_existing_network_subnet }} DNS name server'
-  command:
-    cmd: "openstack subnet set --dns-nameserver {{ vars.os_dns_domain }} {{ use_existing_network_subnet }}"
+- name: 'Update subnet {{ use_existing_network_subnet }}'
+  os_subnet:
+    name: "{{ use_existing_network_subnet }}"
+    network_name: "{{ use_existing_network_name }}"
+    cidr: "{{ os_subnet_range }}"
+    dns_nameservers: "{{ os_dns_domain }}"
+    allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
+    allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+  when:
+  - allocation_pool_start is not defined
+  - allocation_pool_end is not defined 
 
-- name: 'Update subnet {{ use_existing_network_subnet }} allocation pools'
-  command:
-    cmd: "openstack subnet set --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} {{ use_existing_network_subnet }}"
+- name: 'Update subnet {{ use_existing_network_subnet }}'
+  os_subnet:
+    name: "{{ use_existing_network_subnet }}"
+    network_name: "{{ use_existing_network_name }}"
+    cidr: "{{ os_subnet_range }}"
+    dns_nameservers: "{{ os_dns_domain }}"
+    allocation_pool_start: "{{ allocation_pool_start }}"
+    allocation_pool_end: "{{ allocation_pool_end }}"
   when:
   - allocation_pool_start is defined
   - allocation_pool_end is defined 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
@@ -1,0 +1,155 @@
+# =================================================================
+# Copyright 2021 https://github.com/openshift/installer
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =================================================================
+
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+#
+# Change Summary: 
+# - Add port creation
+# - Delete unnecessary Ansible tasks
+# - Use random strings to name compute ports
+
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+
+- name: 'Import common yaml'
+  import_tasks: common.yaml
+
+- name: 'Check existing netowrk name is properly set'
+  fail:
+    msg: "use_existing_network_name is not defined!"
+  failed_when: use_existing_network_name is not defined
+
+- name: 'Check existing netowrk subnet is properly set'
+  fail:
+    msg: "use_existing_network_subnet is not defined!"
+  failed_when: use_existing_network_subnet is not defined
+
+- name: 'Update subnet {{ use_existing_network_subnet }} DNS name server'
+  command:
+    cmd: "openstack subnet set --dns-nameserver {{ vars.os_dns_domain }} {{ use_existing_network_subnet }}"
+
+- name: 'Update subnet {{ use_existing_network_subnet }} allocation pools'
+  command:
+    cmd: "openstack subnet set --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} {{ use_existing_network_subnet }}"
+  when:
+  - allocation_pool_start is defined
+  - allocation_pool_end is defined 
+
+- name: 'Export Infra ID'
+  shell:
+    cmd: "jq -r .infraID metadata.json"
+  register: infra_id
+
+- name: 'Generate random string for the Compute ports and store them in a json file'
+  script: tools/generate-random-compute-json.py {{ infra_id.stdout_lines[0] }} {{ os_compute_nodes_number }}
+  args:
+    executable: python3
+
+- name: 'Read compute nodes names'
+  set_fact:
+    compute_nodes_json: "{{ lookup('file', '.compute-nodes-{{ infra_id.stdout_lines[0] }}.json') | from_json }}"
+
+- name: 'Create the bootstrap server port'
+  os_port:
+    name: "{{ os_port_bootstrap }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+    fixed_ips:
+    - subnet: "{{ os_subnet }}"
+      ip_address: "{{ os_bootstrap_ip }}"
+  when:
+  - auto_allocated_ip == false
+
+- name: 'Create the Control Plane ports'
+  os_port:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+    fixed_ips:
+    - subnet: "{{ os_subnet }}"
+      ip_address: "{{ os_master_ip[item.0] }}"
+  with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+  when:
+  - auto_allocated_ip == false
+
+- name: 'Create the Compute ports'
+  os_port:
+    name: "{{ os_port_worker }}-{{ item.1 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_worker }}"
+    fixed_ips:
+    - subnet: "{{ os_subnet }}"
+      ip_address: "{{ os_infra_ip[item.0]}}"
+  with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"
+  when:
+  - auto_allocated_ip == false
+
+- name: 'Create the bootstrap server port'
+  os_port:
+    name: "{{ os_port_bootstrap }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+  when:
+  - auto_allocated_ip == true
+
+
+- name: 'Create the Control Plane ports'
+  os_port:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_master }}"
+  with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+  when:
+  - auto_allocated_ip == true
+
+- name: 'Create the Compute ports'
+  os_port:
+    name: "{{ os_port_worker }}-{{ item.1 }}"
+    network: "{{ use_existing_network_name }}"
+    security_groups:
+    - "{{ os_sg_worker }}"
+  with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"
+  when:
+  - auto_allocated_ip == true
+    
+- name: 'Set bootstrap port tag'
+  command:
+    cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_bootstrap }}"
+
+- name: 'Set Control Plane ports tag'
+  command:
+    cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
+  with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+
+- name: 'Set Compute ports tag'
+  command:
+    cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_worker }}-{{ item.1 }}"
+  with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"


### PR DESCRIPTION
1. Update inventory.yaml with existing network
test scenario:
1.1) Failed when the user does not specify use_existing_network_name
1.2) Failed when the user does not specify use_existing_network_subnet
1.3) Update DNS name server and allocation pool 
2. Update Readme, and add HAProxy record when user wants to use own DNS and HAProxy.