### PR TITLE
[cloud_infra_center]  Remove destroy network step when executing down-network.yaml

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/down-network.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/down-network.yaml
@@ -60,16 +60,4 @@
   - name: 'Remove the cluster router'
     os_router:
       name: "{{ os_router }}"
-      state: absent
-
-  - name: 'List cluster networks'
-    command:
-      cmd: "openstack network list --tags {{ cluster_id_tag }} -f value -c Name"
-    register: networks
-
-  - name: 'Remove the cluster networks'
-    os_network:
-      name: "{{ item.1}}"
-      state: absent
-    with_indexed_items: "{{ networks.stdout_lines }}"
-    
+      state: absent  


### PR DESCRIPTION
Fix issue 6564 - Remove destroy network step when executing down-network.yaml