### PR TITLE
[cloud_infra_center] Add check for allocation pool

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network-existing/tasks/main.yaml
@@ -71,6 +71,30 @@
   - allocation_pool_start is defined
   - allocation_pool_end is defined 
 
+- name: 'Update subnet {{ use_existing_network_subnet }}'
+  os_subnet:
+    name: "{{ use_existing_network_subnet }}"
+    network_name: "{{ use_existing_network_name }}"
+    cidr: "{{ os_subnet_range }}"
+    dns_nameservers: "{{ os_dns_domain }}"
+    allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
+    allocation_pool_end: "{{ allocation_pool_end }}"
+  when:
+  - allocation_pool_start is not defined
+  - allocation_pool_end is defined 
+
+- name: 'Update subnet {{ use_existing_network_subnet }}'
+  os_subnet:
+    name: "{{ use_existing_network_subnet }}"
+    network_name: "{{ use_existing_network_name }}"
+    cidr: "{{ os_subnet_range }}"
+    dns_nameservers: "{{ os_dns_domain }}"
+    allocation_pool_start: "{{ allocation_pool_start }}"
+    allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+  when:
+  - allocation_pool_start is defined
+  - allocation_pool_end is not defined 
+
 - name: 'Export Infra ID'
   shell:
     cmd: "jq -r .infraID metadata.json"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
@@ -69,6 +69,30 @@
   - allocation_pool_start is defined
   - allocation_pool_end is defined 
 
+- name: 'Create a subnet'
+  os_subnet:
+    name: "{{ os_subnet }}"
+    network_name: "{{ os_network }}"
+    cidr: "{{ os_subnet_range }}"
+    dns_nameservers: "{{ os_dns_domain }}"
+    allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
+    allocation_pool_end: "{{ allocation_pool_end }}"
+  when:
+  - allocation_pool_start is not defined
+  - allocation_pool_end is defined 
+
+- name: 'Create a subnet'
+  os_subnet:
+    name: "{{ os_subnet }}"
+    network_name: "{{ os_network }}"
+    cidr: "{{ os_subnet_range }}"
+    dns_nameservers: "{{ os_dns_domain }}"
+    allocation_pool_start: "{{ allocation_pool_start }}"
+    allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+  when:
+  - allocation_pool_start is defined
+  - allocation_pool_end is not defined 
+
 - name: 'Set the cluster subnet tag'
   command:
     cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet }}"


### PR DESCRIPTION
If user only input one of items of allocation_pool_start or allocation_pool_end, it will skip creating network.
After this change, it will be failed and throw out error msg, if user do so, like this:


```
[root@m5404-integ-contro ocp_upi]# ansible-playbook -i inventory.yaml configure-network.yaml 

PLAY [Configure existing network] ***************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************
ok: [localhost]

TASK [configure-network-existing : Export Infra ID] *********************************************************************************************
changed: [localhost]

TASK [configure-network-existing : Compute resource names] **************************************************************************************
ok: [localhost]

TASK [configure-network-existing : Check existing netowrk name is properly set] *****************************************************************
ok: [localhost]

TASK [configure-network-existing : Check existing netowrk subnet is properly set] ***************************************************************
ok: [localhost]

TASK [configure-network-existing : Check allocation_pool_start is properly set] *****************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed_when_result": true, "msg": "allocation_pool_start is not defined while allocation_pool_end is defined!"}

PLAY RECAP **************************************************************************************************************************************
localhost                  : ok=5    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

[root@m5404-integ-contro ocp_upi]# ansible-playbook -i inventory.yaml configure-network.yaml 

PLAY [Configure existing network] ***************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************
ok: [localhost]

TASK [configure-network-existing : Export Infra ID] *********************************************************************************************
changed: [localhost]

TASK [configure-network-existing : Compute resource names] **************************************************************************************
ok: [localhost]

TASK [configure-network-existing : Check existing netowrk name is properly set] *****************************************************************
ok: [localhost]

TASK [configure-network-existing : Check existing netowrk subnet is properly set] ***************************************************************
ok: [localhost]

TASK [configure-network-existing : Check allocation_pool_start is properly set] *****************************************************************
ok: [localhost]

TASK [configure-network-existing : Check allocation_pool_end is properly set] *******************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed_when_result": true, "msg": "allocation_pool_end is not defined while allocation_pool_start is defined!"}

PLAY RECAP **************************************************************************************************************************************
localhost                  : ok=6    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  
```
