### PR TITLE
Fix-ocp-6751: Add scsi disk type when creating nodes

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
@@ -73,6 +73,24 @@
       availability_zone: "{{ availability_zone }}"
       nics:
       - port-name: "{{ os_port_worker }}-{{ compute_nodes_json.compute_node_names[-1] }}"
+    when:
+    - disk_type == "dasd"
+
+  - name: 'Create the Compute servers with boot volume'
+    os_server:
+      name: "{{ os_compute_server_name }}-{{ compute_nodes_json.compute_node_names[-1] }}"
+      image: "rhcos"
+      flavor: "{{ os_flavor_worker }}"
+      auto_ip: no
+      timeout: 2400
+      userdata: "{{ lookup('file', 'worker.ign') | string }}"
+      availability_zone: "{{ availability_zone }}"
+      nics:
+      - port-name: "{{ os_port_worker }}-{{ compute_nodes_json.compute_node_names[-1] }}"
+      boot_from_volume: True
+      terminate_volume: True
+    when:
+    - disk_type == "scsi"
 
   - name: 'Approve worker nodes csr'
     script: tools/wait-nodes-csrs.py {{ os_compute_server_name }}-{{ compute_nodes_json.compute_node_names[-1] }}

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
@@ -50,3 +50,22 @@
     nics:
     - port-name: "{{ os_port_bootstrap }}"
     meta: "{{ cluster_id_tag }}"
+  when:
+  - disk_type == "dasd"
+
+- name: 'Create the bootstrap server with boot volume'
+  os_server:
+    name: "{{ os_bootstrap_server_name }}"
+    image: "rhcos"
+    flavor: "{{ os_flavor_master }}"
+    userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
+    timeout: 3600
+    auto_ip: no
+    availability_zone: "{{ availability_zone }}"
+    nics:
+    - port-name: "{{ os_port_bootstrap }}"
+    meta: "{{ cluster_id_tag }}"
+    boot_from_volume: True
+    terminate_volume: True
+  when:
+  - disk_type == "scsi"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
@@ -60,6 +60,26 @@
     - port-name: "{{ os_port_worker }}-{{ item.1 }}"
     meta: "{{ cluster_id_tag }}"
   with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"
+  when:
+  - disk_type == "dasd"
+
+- name: 'Create the Compute servers with boot volume'
+  os_server:
+    name: "{{ os_compute_server_name }}-{{ item.1 }}"
+    image: "rhcos"
+    flavor: "{{ os_flavor_worker }}"
+    auto_ip: no
+    availability_zone: "{{ availability_zone }}"
+    timeout: 2400
+    userdata: "{{ lookup('file', 'worker.ign') | string }}"
+    nics:
+    - port-name: "{{ os_port_worker }}-{{ item.1 }}"
+    meta: "{{ cluster_id_tag }}"
+    boot_from_volume: True
+    terminate_volume: True
+  with_indexed_items: "{{ compute_nodes_json.compute_node_names }}"
+  when:
+  - disk_type == "scsi"
 
 - name: 'Approve worker nodes csr'
   script: tools/wait-nodes-csrs.py {{ os_compute_server_name }}-{{ item.1 }}

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -87,3 +87,31 @@
   with_indexed_items: "{{ [os_cp_server_name] * os_cp_nodes_number }}"
   environment: 
     PYTHONWARNINGS: 'ignore::UserWarning'
+  when:
+  - disk_type == "dasd"
+
+  - name: 'Create the Control Plane servers with boot volume'
+  os_server:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    image: "rhcos"
+    flavor: "{{ os_flavor_master }}"
+    auto_ip: no
+    availability_zone: "{{ availability_zone }}"
+    timeout: 2400
+    # The ignition filename will be concatenated with the Control Plane node
+    # name and its 0-indexed serial number.
+    # In this case, the first node will look for this filename:
+    #    "{{ infraID }}-master-0-ignition.json"
+    userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
+    nics:
+    - port-name: "{{ os_port_master }}-{{ item.0 }}"
+    scheduler_hints:
+      group: "{{ server_group_id }}"
+    meta: "{{ cluster_id_tag }}"
+    boot_from_volume: True
+    terminate_volume: True
+  with_indexed_items: "{{ [os_cp_server_name] * os_cp_nodes_number }}"
+  environment: 
+    PYTHONWARNINGS: 'ignore::UserWarning'
+  when:
+  - disk_type == "scsi"


### PR DESCRIPTION
Add disk type support for "scsi" when creating bootstrap, master and worker.

Test on 172.26.4.143 test stand:
```
[root@m5404-integ-contro ocp_upi]# ansible-playbook -i inventory.yaml configure-bootstrap.yaml

PLAY [Create the bootstrap server] **********************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************
ok: [localhost]

TASK [configure-bootstrap : Export Infra ID] ************************************************************************************************************************************************************
changed: [localhost]

TASK [configure-bootstrap : Compute resource names] *****************************************************************************************************************************************************
ok: [localhost]

TASK [configure-bootstrap : Create the bootstrap server] ************************************************************************************************************************************************
skipping: [localhost]

TASK [configure-bootstrap : Create the bootstrap server with boot volume] *******************************************************************************************************************************
changed: [localhost]

PLAY RECAP **********************************************************************************************************************************************************************************************
localhost                  : ok=4    changed=2    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```