### PR TITLE
[cloud_infra_center] Fix a syntax typo in configure-control-plane.yaml

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -90,7 +90,7 @@
   when:
   - disk_type == "dasd"
 
-  - name: 'Create the Control Plane servers with boot volume'
+- name: 'Create the Control Plane servers with boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
     image: "rhcos"


### PR DESCRIPTION
Fix a syntax error in configure-control-plane.yaml, which was brought in https://github.com/IBM/z_ansible_collections_samples/pull/91.