### PR TITLE
Add named owner and group on DNS definition

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-dns/tasks/main.yml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-dns/tasks/main.yml
@@ -32,6 +32,8 @@
   template:
     src: var/named/cluster_domain_name.zone.j2
     dest: /var/named/{{ cluster_domain_name }}.zone
+    owner: named
+    group: named
   notify:
    - restart dns
 
@@ -54,6 +56,8 @@
   template:
     src: var/named/bastion.in-addr.arpa.zone.j2
     dest: /var/named/{{ bastion_subnet_prefix_reverse }}.in-addr.arpa.zone
+    owner: named
+    group: named
   notify:
    - restart dns
  


### PR DESCRIPTION
1) Deploy OCP successfully with this PR on KVM test stand 100.8 ( allocated_ip = true) 
```
I have tested all changes successfully in ansible 2.8.18.

[root@bastion2 ocp_upi]# ansible --version
ansible 2.8.18
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.8 (default, Mar 18 2021, 08:58:30) [GCC 8.4.1 20200928 (Red Hat 8.4.1-1)]
[root@bastion2 ocp_upi]# oc get nodes
NAME                       STATUS   ROLES    AGE    VERSION
host-172-26-105-63         Ready    worker   3m7s   v1.20.0+c8905da
host-172-26-105-68         Ready    worker   3m9s   v1.20.0+c8905da
openshift-5zb9r-master-0   Ready    master   40m    v1.20.0+c8905da
openshift-5zb9r-master-1   Ready    master   40m    v1.20.0+c8905da
openshift-5zb9r-master-2   Ready    master   40m    v1.20.0+c8905da
[root@bastion2 ocp_upi]#
```
2) Deploy OCP successfully with this PR on ZVM test stand 176. ( allocated_ip = false) 
```
[root@os015 ocp_upi]# oc get nodes
NAME                           STATUS   ROLES    AGE    VERSION
openshift-kl6xs-master-0       Ready    master   21m    v1.21.1+051ac4f
openshift-kl6xs-master-1       Ready    master   20m    v1.21.1+051ac4f
openshift-kl6xs-master-2       Ready    master   19m    v1.21.1+051ac4f
openshift-kl6xs-worker-64549   Ready    worker   9m7s   v1.21.1+051ac4f
openshift-kl6xs-worker-f2c77   Ready    worker   10m    v1.21.1+051ac4f
openshift-kl6xs-worker-f49c8   Ready    worker   11m    v1.21.1+051ac4f
[root@os015 ocp_upi]#
```