### PR TITLE
Added .gitattributes to detect YAML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.yaml linguist-detectable=true
+*.yaml linguist-language=YAML
+*.yml linguist-detectable=true
+*.yml linguist-language=YAML


### PR DESCRIPTION
Added a .gitattributes file to fix the Languages bar on the GitHub repository page that shows what programming languages are used, which currently does not include YAML. Clicking on that Languages bar shows that linguist detects it, it's just not included in the bar for some reason. I had the same issue with my Ansible repo, and the proposed additions fixed it for me. I also tested these lines on my own forked repo and it worked there too.

Signed-off-by: jacobemery <jacob.emery@ibm.com>