### PR TITLE
Add .gitattributes to detect YAML

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.yaml linguist-detectable=true
+*.yaml linguist-language=YAML
+*.yml linguist-detectable=true
+*.yml linguist-language=YAML


### PR DESCRIPTION
Add a .gitattributes file with line for linguist to detect YAML so that it is shown in the 'Languages' bar on the repository's main page.

Signed-off-by: Jacob Emery <jacob.emery@ibm.com>