### PR TITLE
[cloud_infra_center]convert node flavor from value to number

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -6,7 +6,7 @@ Before you get started with Ansible, familiarize yourself with the basics of Red
 
  [Red Hat OpenShift Container Platform installation and update](https://docs.openshift.com/container-platform/4.8/architecture/architecture-installation.html#architecture-installation)
 
-[IBM Cloud Infrastructure Center](https://www.ibm.com/docs/en/cic/1.1.4)
+[IBM Cloud Infrastructure Center](https://www.ibm.com/docs/en/cic/1.1.5)
 
 # About this playbook
 
@@ -34,7 +34,7 @@ The playbook contains the following topics:
 
   3. Requirements pre-check before the installation
 
-**Note**: This playbook supports IBM® Cloud Infrastructure Center version 1.1.4, 1.1.5 and RH OpenShift Container Platform version 4.6 and, 4.7, 4.8, 4.9 for z/VM and version 4.7, 4.8, 4.9 for KVM.
+**Note**: This playbook supports IBM® Cloud Infrastructure Center version 1.1.4, 1.1.5 and RH OpenShift Container Platform version 4.6 and, 4.7, 4.8, 4.9, 4.10 for z/VM and version 4.7, 4.8, 4.9, 4.10 for KVM.
 
 # Installing Red Hat OpenShift on the IBM Cloud Infrastructure Center via user-provisioned infrastructure (UPI)
 
@@ -112,7 +112,7 @@ sudo subscription-manager register --username <username> --password <password> -
 ```
 After registration, use the following command to enable ansible repository, or use a newer version of your installed systems. 
 
-**Note:** Our scenario is only tested for Ansible 2.8.18 on RHEL 8.2. 
+**Note:** Our scenario is only tested for Ansible 2.8.18 on RHEL 8.2, RHEL8.3 and RHEL8.5. 
 ```sh
 sudo subscription-manager repos --enable=ansible-2.8-for-rhel-8-s390x-rpms 
 ```
@@ -172,7 +172,7 @@ openstack
 
 ### 3. Setting the IBM Cloud Infrastructure Center environment variables on your Linux server
 
-Check’ [setting environment variables](https://www.ibm.com/docs/en/cic/1.1.4?topic=descriptions-setting-environment-variables) for more details.
+Check’ [setting environment variables](https://www.ibm.com/docs/en/cic/1.1.5?topic=descriptions-setting-environment-variables) for more details.
 
 1. If your Linux server does not have SSH key, use the following command-line SSH to generate a key pair: 
 ```sh
@@ -226,7 +226,7 @@ icic-services status
 ```
 - Login to the IBM Cloud Infrastructure Center web console and select Home > Environment Checker, click the Run Environment Checker button to confirm the cluster does not have any failed messages.
 
-If you meet any **not running** service or **failed** message, check the IBM Cloud Infrastructure Center [Troubleshooting](https://www.ibm.com/docs/en/cic/1.1.4?topic=troubleshooting) document to fix before running the ansible playbook.
+If you meet any **not running** service or **failed** message, check the IBM Cloud Infrastructure Center [Troubleshooting](https://www.ibm.com/docs/en/cic/1.1.5?topic=troubleshooting) document to fix before running the ansible playbook.
 
 
 ### 4. Download this playbook on your Linux server
@@ -248,8 +248,8 @@ Update your settings based on the samples. The following propeties are **require
 | `use_network_subnet` | \<subnet id from network name in icic\> |`openstack network list -c Subnets -f value`|
 | `vm_type` | kvm| The operation system of OpenShift Container Platform, <br>supported: `kvm` or `zvm`| |
 | `disk_type` | dasd|The disk storage of OpenShift Container Platform, <br>supported: `dasd` or `scsi` | |
-| `openshift_version` |4.7| The product version of OpenShift Container Platform, <br>such as `4.6` or `4.7` or `4.8`| |
-| `openshift_minor_version` |7| The minor version of Openshift Container Platform, <br>such as `7` or `13` | 
+| `openshift_version` |4.10| The product version of OpenShift Container Platform, <br>such as `4.6` or `4.7` or `4.8`| |
+| `openshift_minor_version` |3| The minor version of Openshift Container Platform, <br>such as `7` or `13` | 
 | `auto_allocated_ip` |true|(Boolean) true or false, if false, <br>IPs will be allocated from `allocation_pool_start` and `allocation_pool_end` |
 | `os_flavor_bootstrap` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB  | |
 | `os_flavor_master` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB | |

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
@@ -53,6 +53,13 @@
   when:
   - disk_type == "dasd"
 
+- name: 'Convert bootstrap flavor from value into number'
+  command:
+    cmd: "openstack flavor show {{ os_flavor_bootstrap }} -c disk -f value"
+  register: bootstrap_flavor_size
+  when:
+  - disk_type == "scsi"
+
 - name: 'Create the bootstrap server with boot volume'
   os_server:
     name: "{{ os_bootstrap_server_name }}"
@@ -66,6 +73,7 @@
     - port-name: "{{ os_port_bootstrap }}"
     meta: "{{ cluster_id_tag }}"
     boot_from_volume: True
+    volume_size: "{{ bootstrap_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
   when:
   - disk_type == "scsi"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
@@ -59,6 +59,13 @@
   when:
   - disk_type == "dasd"
 
+- name: 'Convert compute node flavor from value into number'
+  command:
+    cmd: "openstack flavor show {{ os_flavor_worker }} -c disk -f value"
+  register: compute_flavor_size
+  when:
+  - disk_type == "scsi"
+
 - name: 'Create the Compute servers with boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
@@ -72,6 +79,7 @@
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
     meta: "{{ cluster_id_tag }}"
     boot_from_volume: True
+    volume_size: "{{ compute_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -90,6 +90,13 @@
   when:
   - disk_type == "dasd"
 
+- name: 'Convert master flavor from value into number'
+  command:
+    cmd: "openstack flavor show {{ os_flavor_master }} -c disk -f value"
+  register: master_flavor_size
+  when:
+  - disk_type == "scsi"
+
 - name: 'Create the Control Plane servers with boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
@@ -109,6 +116,7 @@
       group: "{{ server_group_id }}"
     meta: "{{ cluster_id_tag }}"
     boot_from_volume: True
+    volume_size: "{{ master_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
   with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
   environment: 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-haproxy/templates/etc/haproxy/haproxy.cfg.j2
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-haproxy/templates/etc/haproxy/haproxy.cfg.j2
@@ -81,7 +81,7 @@ backend ocp4-router-http
    {% endfor %}
 {% else %}
    {% for item in masters.keys() %}
-      server {{ item }} {{ item }}.{{ cluster_name }}.{{ base_domain }}:22623 check
+      server {{ item }} {{ item }}.{{ cluster_name }}.{{ base_domain }}:80 check
    {% endfor %}
 {% endif %}
 
@@ -93,6 +93,6 @@ backend ocp4-router-https
    {% endfor %}
 {% else %}
    {% for item in masters.keys() %}
-   server {{ item }} {{ item }}.{{ cluster_name }}.{{ base_domain }}:22623 check
+   server {{ item }} {{ item }}.{{ cluster_name }}.{{ base_domain }}:443 check
    {% endfor %}
 {% endif %}


### PR DESCRIPTION
Fix customized volume size when creating bootstrap, control and compute nodes with SCSI disk_type.
1) add volume_size parameter
2) convet the flavor from value to number.

Test this pr on zvm test stand：
<img width="547" alt="image" src="https://user-images.githubusercontent.com/74761704/159220951-75e38532-64bb-4e33-9e24-72ed51c35508.png">

```
TASK [Show bootstrapping log] **************************************************************************************************************************************************************************
ok: [localhost] => {
    "bootstrap_log.stdout_lines": [
        "time=\"2022-03-21T03:31:41-04:00\" level=info msg=\"Waiting up to 30m0s (until 4:01AM) for bootstrapping to complete...\"",
        "time=\"2022-03-21T03:37:31-04:00\" level=debug msg=\"Bootstrap status: complete\"",
        "time=\"2022-03-21T03:37:31-04:00\" level=info msg=\"It is now safe to remove the bootstrap resources\"",
        "time=\"2022-03-21T03:37:31-04:00\" level=debug msg=\"Time elapsed per stage:\"",
        "time=\"2022-03-21T03:37:31-04:00\" level=debug msg=\"Bootstrap Complete: 5m50s\"",
        "time=\"2022-03-21T03:37:31-04:00\" level=info msg=\"Time elapsed: 5m50s\""
    ]
}

PLAY RECAP *********************************************************************************************************************************************************************************************
localhost                  : ok=17   changed=11   unreachable=0    failed=0    skipped=3    rescued=0    ignored=0

[root@os015 ocp_upi]#
```

Test passed, please help to review and merge it.