### PR TITLE
[cloud_infra_center] add storage template when deploying nodes

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -254,8 +254,8 @@ Update your settings based on the samples. The following propeties are **require
 | `os_flavor_bootstrap` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB  | |
 | `os_flavor_master` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB | |
 | `os_flavor_worker` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB  | |
-| `os_control_nodes_number` |3| (Integer) Number of Red Hat Openshift provisioned Control Plane nodes| |
-| `os_compute_nodes_number` |3| (Integer) Number of Red Hat Openshift provisioned Compute nodes| |
+| `os_control_nodes_number` |3| (Integer) Number of Red Hat Openshift provisioned control server nodes| |
+| `os_compute_nodes_number` |3| (Integer) Number of Red Hat Openshift provisioned compute server nodes| |
 | `create_server_zone` |''| The zone you can select which host instances are launched on and which roles can boot instances on this host, the value format is `ZONE:HOST:NODE`, HOST and NODE are optional parameters, in such cases, use the `ZONE::NODE`, `ZONE:HOST` or `ZONE`. <br>Default value is '', which means to use the default availability zone. <br>[ **ZONE** is `Zone Name` column from `openstack availability zone list`; **HOST** is `Host Name` column from `openstack host list`; **NODE** is `Hypervisor Hostname` column from `openstack hypervisor list`]|
 | `pullsecret` | \<pull-secret\> |  Get from [cloud.redhat.com](https://console.redhat.com/openshift/install/ibmz/user-provisioned)|
 | `sshkey` | \<ssh-key\>| The SSH public key for the core user in RHEL CoreOS |
@@ -279,11 +279,13 @@ Others are **optional**, you can enable them and update value if you need more s
 | `os_bootstrap_ip` | \<bootstrap ip addr\> |'x.x.x.x, <br>**required** when `auto_allocated_ip` is false
 | `os_master_ip` | \<master ip list\>|'[x.x.x.x, x.x.x.x, x.x.x.x], <br>**required** when `auto_allocated_ip` is false
 | `os_infra_ip` |\<infra ip list\>|'[x.x.x.x, x.x.x.x, x.x.x.x], <br>**required** when `auto_allocated_ip` is false
+| `volume_type_id` |\<storage template id\>|The bootable volume type from backend storage provider. Get it from `openstack volume type list -c ID -f value`
 | `use_proxy` |false|(Boolean) true or false, if true then Openshft Container Platform will use the proxy setting, get detail from [doc.openshift.com](https://docs.openshift.com/container-platform/4.9/installing/installing_bare_metal/installing-bare-metal.html#installation-configure-proxy_installing-bare-metal)
 | `http_proxy` |\<http-proxy\>| `http://<username>:<pswd>@<ip>:<port>`, a proxy URL to use for creating HTTP connections outside the cluster. <br>**required** when `use_proxy` is true
 | `https_proxy` |\<https-proxy\>| `http://<username>:<pswd>@<ip>:<port>`, a proxy URL to use for creating HTTPS connections outside the cluster <br>**required** when `use_proxy` is true
 | `no_proxy` |\<https-proxy\>| A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying. Preface a domain with . to include all subdomains of that domain. Use * to bypass proxy for all destinations. <br>Such as: `'127.0.0.1,169.254.169.254,172.26.0.0/17,172.30.0.0/16,10.0.0.0/16,10.128.0.0/14,localhost,.api-int.,.example.com.'`
 | `approve_nodes_csr` |10| Default is 10 minutes that used to wait for approving node csrs
+| `create_server_timeout` |10| Default is 10 minutes that used to create instances and volumes from backend storage provider
 
 ## Creation of the cluster
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
@@ -21,7 +21,7 @@
   - name: 'Import common yaml'
     import_tasks: common.yaml
 
-  - name: 'Export Infra ID'
+  - name: 'Export infra ID'
     shell:
       cmd: "jq -r .infraID metadata.json"
     register: infra_id
@@ -44,7 +44,7 @@
   - name: 'Generate worker node json file'
     script: tools/generate-new-worker-ignition.sh {{ os_compute_server_name }}-{{ new_worker_index }}
 
-  - name: 'Create the Compute ports'
+  - name: 'Create the compute server ports'
     os_port:
       name: "{{ os_port_worker }}-{{ new_worker_index }}"
       network: "{{ use_network_name }}"
@@ -57,7 +57,7 @@
     when:
     - auto_allocated_ip == false
 
-  - name: 'Create the Compute ports'
+  - name: 'Create the compute server ports'
     os_port:
       name: "{{ os_port_worker }}-{{ new_worker_index }}"
       network: "{{ use_network_name }}"
@@ -67,39 +67,84 @@
     when:
     - auto_allocated_ip == true
 
-  - name: 'Set Compute ports tag'
+  - name: 'Set compute server ports tag'
     command:
       cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_worker }}-{{ new_worker_index }}"
 
-  - name: 'Create the Compute servers'
+  - name: 'Create the compute servers'
     os_server:
       name: "{{ os_compute_server_name }}-{{ new_worker_index }}"
       image: "rhcos"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
-      timeout: 2400
+      timeout: "{{ create_server_timeout|int * 60 }}"
       userdata: "{{ lookup('file', [ os_compute_server_name , new_worker_index , 'ignition.json'] | join('-')) | string }}"
       availability_zone: "{{ create_server_zone }}"
       nics:
       - port-name: "{{ os_port_worker }}-{{ new_worker_index }}"
     when:
     - disk_type == "dasd"
+  
+  - name: 'Convert compute server flavor from value into number'
+    command:
+      cmd: "openstack flavor show {{ os_flavor_worker }} -c disk -f value"
+    register: compute_flavor_size
+    when:
+    - disk_type == "scsi"
 
-  - name: 'Create the Compute servers with boot volume'
+  - name: 'Create the compute servers with default boot volume'
     os_server:
       name: "{{ os_compute_server_name }}-{{ new_worker_index }}"
       image: "rhcos"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
-      timeout: 2400
+      timeout: "{{ create_server_timeout|int * 60 }}"
       userdata: "{{ lookup('file', [ os_compute_server_name , new_worker_index , 'ignition.json'] | join('-')) | string }}"
       availability_zone: "{{ create_server_zone }}"
       nics:
       - port-name: "{{ os_port_worker }}-{{ new_worker_index }}"
       boot_from_volume: True
+      volume_size: "{{ compute_flavor_size.stdout_lines[0]}}"
       terminate_volume: True
     when:
     - disk_type == "scsi"
+    - volume_type_id is not defined
+
+  - name: 'Create compute boot volume'
+    os_volume:
+      state: present
+      name: "{{ os_compute_server_name }}-{{ new_worker_index }}-boot"
+      image: "rhcos"
+      size: "{{ compute_flavor_size.stdout_lines[0]}}"
+      volume_type: "{{ volume_type_id }}"
+      metadata: "{{ cluster_id_tag }}"
+      timeout: "{{ create_server_timeout|int * 60 }}" 
+    when:
+    - disk_type == "scsi"
+    - volume_type_id is defined
+  
+  - name: 'Set compute volume bootable'
+    shell: openstack volume set --bootable "{{ os_compute_server_name }}-{{ new_worker_index }}-boot"
+    when: 
+    - disk_type == "scsi"
+    - volume_type_id is defined
+
+  - name: 'Create the compute server with boot volume'
+    os_server:
+      name: "{{ os_compute_server_name }}-{{ new_worker_index }}"
+      flavor: "{{ os_flavor_worker }}"
+      boot_volume: "{{ os_compute_server_name }}-{{ new_worker_index }}-boot"
+      auto_ip: no
+      availability_zone: "{{ create_server_zone }}"
+      timeout: "{{ create_server_timeout|int * 60 }}" 
+      userdata: "{{ lookup('file', [ os_compute_server_name , new_worker_index , 'ignition.json'] | join('-')) | string }}"
+      nics:
+      - port-name: "{{ os_port_worker }}-{{ new_worker_index }}"
+      meta: "{{ cluster_id_tag }}"
+      terminate_volume: True
+    when:
+    - disk_type == "scsi"
+    - volume_type_id is defined
   
   - name: Get new node IP
     environment:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/common.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/common.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 # =================================================================
 
-- name: 'Export Infra ID'
+- name: 'Export infra ID'
   shell:
     cmd: "jq -r .infraID metadata.json"
   register: infra_id

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-install-config.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-install-config.yaml
@@ -8,7 +8,7 @@
 # =================================================================
 
 ---
-- name: Configure Install Config
+- name: Configure install config
   hosts: localhost
   roles:
   - configure-install-config

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-install-ignition.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-install-ignition.yaml
@@ -8,7 +8,7 @@
 # =================================================================
 
 ---
-- name: Configure Install Ignition
+- name: Configure install ignition
   hosts: localhost
   roles:
   - configure-install-ignition

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-install-manifests.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-install-manifests.yaml
@@ -8,7 +8,7 @@
 # =================================================================
 
 ---
-- name: Configure Install Manifests
+- name: Configure install manifests
   hosts: localhost
   roles:
   - configure-install-manifests

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-computes.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-computes.yaml
@@ -40,18 +40,18 @@
   - name: 'Import common yaml'
     import_tasks: common.yaml
 
-  - name: 'Export Infra ID'
+  - name: 'Export infra ID'
     shell:
       cmd: "jq -r .infraID metadata.json"
     register: infra_id
 
-  - name: 'Remove the Compute servers'
+  - name: 'Remove the compute servers'
     os_server:
       name: "{{ item.1 }}-{{ item.0 }}"
       state: absent
     with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
 
-  - name: 'Get Compute servers from ICIC command line'
+  - name: 'Get compute servers from ICIC command line'
     shell: |
        openstack server list -c Name -f value | grep worker
     register: computes

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-controls.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-controls.yaml
@@ -27,19 +27,19 @@
   - name: 'Import common yaml'
     import_tasks: common.yaml
 
-  - name: 'Remove the Control Plane servers'
+  - name: 'Remove the control servers'
     os_server:
       name: "{{ item.1 }}-{{ item.0 }}"
       state: absent
     with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
 
-  - name: 'List the Server groups'
+  - name: 'List the server groups'
     command:
       # os-compute-api-version 2.15 or higher is required for the 'soft-anti-affinity' policy
       cmd: "openstack --os-compute-api-version=2.15 server group list -f json -c ID -c Name"
     register: server_group_list
 
-  - name: 'Parse the Server group ID from existing'
+  - name: 'Parse the server group ID from existing'
     set_fact:
       server_group_id: "{{ (server_group_list.stdout | from_json | json_query(list_query) | first).ID }}"
     vars:
@@ -47,7 +47,7 @@
     when:
     - "os_cp_server_group_name|string in server_group_list.stdout"
 
-  - name: 'Remove the Control Plane server group'
+  - name: 'Remove the control server group'
     command:
       # os-compute-api-version 2.15 or higher is required for the 'soft-anti-affinity' policy
       cmd: "openstack --os-compute-api-version=2.15 server group delete {{ server_group_id }}"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-images-files.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-images-files.yaml
@@ -64,7 +64,7 @@
       path: auth/
       state: absent
   
-  - name: 'Remove the file of Compute server names'
+  - name: 'Remove the file of compute server names'
     file:
       state: absent
       path: .compute-nodes-{{ infra_id.stdout_lines[0] }}.json

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -39,6 +39,8 @@ all:
 
       vm_type: 'kvm' # kvm or zvm
       disk_type: 'dasd' # dasd or scsi
+      #volume_type_id: '<storage-template-id>'
+      
       openshift_version: '4.7'
       openshift_minor_version: '7'
       
@@ -63,6 +65,7 @@ all:
       #no_proxy: '<no-proxy>'
 
       approve_nodes_csr: 10 # minute
+      create_server_timeout: 10 # minute
 
     bastion:
       ansible_ssh_host: '<linux-server-ip-addr>'

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bastion-properties/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bastion-properties/tasks/main.yaml
@@ -10,7 +10,7 @@
 ---
 # tasks file for configure-bastion-properties
 
-- name: Get Nodes IP and store into yaml file
+- name: Get nodes IP and store into yaml file
   script: tools/modify-bastion.py
   args:
     executable: python3

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
@@ -44,7 +44,7 @@
     image: "rhcos"
     flavor: "{{ os_flavor_bootstrap }}"
     userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
-    timeout: 3600
+    timeout: "{{ create_server_timeout|int * 60 }}" 
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
     nics:
@@ -60,13 +60,13 @@
   when:
   - disk_type == "scsi"
 
-- name: 'Create the bootstrap server with boot volume'
+- name: 'Create the bootstrap server with default boot volume'
   os_server:
     name: "{{ os_bootstrap_server_name }}"
     image: "rhcos"
     flavor: "{{ os_flavor_bootstrap }}"
     userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
-    timeout: 3600
+    timeout: "{{ create_server_timeout|int * 60 }}" 
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
     nics:
@@ -77,3 +77,40 @@
     terminate_volume: True
   when:
   - disk_type == "scsi"
+  - volume_type_id is not defined
+
+- name: 'Create bootstrap boot volume'
+  os_volume:
+    state: present
+    name: "{{ os_bootstrap_server_name }}-boot"
+    image: "rhcos"
+    size: "{{ bootstrap_flavor_size.stdout_lines[0]}}"
+    volume_type: "{{ volume_type_id }}"
+    metadata: "{{ cluster_id_tag }}"
+    timeout: "{{ create_server_timeout|int * 60 }} "
+  when: 
+  - disk_type == "scsi"
+  - volume_type_id is defined
+
+- name: 'Set bootstrap volume bootable'
+  shell: openstack volume set --bootable "{{ os_bootstrap_server_name }}-boot"
+  when: 
+  - disk_type == "scsi"
+  - volume_type_id is defined
+
+- name: 'Create the bootstrap server with boot volume'
+  os_server:
+    name: "{{ os_bootstrap_server_name }}"
+    flavor: "{{ os_flavor_bootstrap }}"
+    boot_volume: "{{ os_bootstrap_server_name }}-boot"
+    userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
+    timeout: "{{ create_server_timeout|int * 60 }}"
+    auto_ip: no
+    availability_zone: "{{ create_server_zone }}"
+    nics:
+    - port-name: "{{ os_port_bootstrap }}"
+    meta: "{{ cluster_id_tag }}"
+    terminate_volume: True
+  when:
+  - disk_type == "scsi"
+  - volume_type_id is defined

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
@@ -38,19 +38,19 @@
 - name: 'Import common yaml'
   import_tasks: common.yaml
 
-- name: Export Infra ID
+- name: Export infra ID
   shell:
     cmd: "jq -r .infraID metadata.json"
   register: infra_id
 
-- name: 'Create the Compute servers'
+- name: 'Create the compute servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
     image: "rhcos"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
-    timeout: 2400
+    timeout: "{{ create_server_timeout|int * 60 }}" 
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
@@ -66,14 +66,14 @@
   when:
   - disk_type == "scsi"
 
-- name: 'Create the Compute servers with boot volume'
+- name: 'Create the compute servers with default boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
     image: "rhcos"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
-    timeout: 2400
+    timeout: "{{ create_server_timeout|int * 60 }}" 
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
@@ -84,3 +84,43 @@
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:
   - disk_type == "scsi"
+  - volume_type_id is not defined
+
+- name: 'Create compute boot volume'
+  os_volume:
+    state: present
+    name: "{{ item.1 }}-{{ item.0 }}-boot"
+    image: "rhcos"
+    size: "{{ compute_flavor_size.stdout_lines[0]}}"
+    volume_type: "{{ volume_type_id }}"
+    metadata: "{{ cluster_id_tag }}"
+    timeout: "{{ create_server_timeout|int * 60 }}" 
+  with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
+  when:
+  - disk_type == "scsi"
+  - volume_type_id is defined
+
+- name: 'Set compute volume bootable'
+  shell: openstack volume set --bootable "{{ item.1 }}-{{ item.0 }}-boot"
+  with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
+  when: 
+  - disk_type == "scsi"
+  - volume_type_id is defined
+
+- name: 'Create the compute server with boot volume'
+  os_server:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    flavor: "{{ os_flavor_worker }}"
+    boot_volume: "{{ item.1 }}-{{ item.0 }}-boot"
+    auto_ip: no
+    availability_zone: "{{ create_server_zone }}"
+    timeout: "{{ create_server_timeout|int * 60 }}" 
+    userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
+    nics:
+    - port-name: "{{ os_port_worker }}-{{ item.0 }}"
+    meta: "{{ cluster_id_tag }}"
+    terminate_volume: True
+  with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
+  when:
+  - disk_type == "scsi"
+  - volume_type_id is defined

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -38,13 +38,13 @@
 - name: 'Import common yaml'
   import_tasks: common.yaml
 
-- name: 'List the Server groups'
+- name: 'List the server groups'
   command:
     # os-compute-api-version 2.15 or higher is required for the 'soft-anti-affinity' policy
     cmd: "openstack --os-compute-api-version=2.15 server group list -f json -c ID -c Name"
   register: server_group_list
 
-- name: 'Parse the Server group ID from existing'
+- name: 'Parse the server group ID from existing'
   set_fact:
     server_group_id: "{{ (server_group_list.stdout | from_json | json_query(list_query) | first).ID }}"
   vars:
@@ -52,7 +52,7 @@
   when:
   - "os_cp_server_group_name|string in server_group_list.stdout"
 
-- name: 'Create the Control Plane server group'
+- name: 'Create the control server group'
   command:
     # os-compute-api-version 2.15 or higher is required for the 'soft-anti-affinity' policy
     cmd: "openstack --os-compute-api-version=2.15 server group create -f json -c id --policy=soft-anti-affinity {{ os_cp_server_group_name }}"
@@ -60,20 +60,20 @@
   when:
   - server_group_id is not defined
 
-- name: 'Parse the Server group ID from creation'
+- name: 'Parse the server group ID from creation'
   set_fact:
     server_group_id: "{{ (server_group_created.stdout | from_json).id }}"
   when:
   - server_group_id is not defined
 
-- name: 'Create the Control Plane servers'
+- name: 'Create the control servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
     image: "rhcos"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
-    timeout: 2400
+    timeout: "{{ create_server_timeout|int * 60 }}" 
     # The ignition filename will be concatenated with the Control Plane node
     # name and its 0-indexed serial number.
     # In this case, the first node will look for this filename:
@@ -97,14 +97,14 @@
   when:
   - disk_type == "scsi"
 
-- name: 'Create the Control Plane servers with boot volume'
+- name: 'Create the control servers with default boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
     image: "rhcos"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
-    timeout: 2400
+    timeout: "{{ create_server_timeout|int * 60 }}" 
     # The ignition filename will be concatenated with the Control Plane node
     # name and its 0-indexed serial number.
     # In this case, the first node will look for this filename:
@@ -123,3 +123,45 @@
     PYTHONWARNINGS: 'ignore::UserWarning'
   when:
   - disk_type == "scsi"
+  - volume_type_id is not defined
+  
+- name: Create control boot volume
+  os_volume:
+    state: present
+    name: "{{ item.1 }}-{{ item.0 }}-boot"
+    image: "rhcos"
+    size: "{{ master_flavor_size.stdout_lines[0]}}"
+    volume_type: "{{ volume_type_id }}"
+    metadata: "{{ cluster_id_tag }}"
+    timeout: "{{ create_server_timeout|int * 60 }}" 
+  with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
+  when: 
+  - disk_type == "scsi"
+  - volume_type_id is defined
+
+- name: 'Set control volume bootable'
+  shell: openstack volume set --bootable "{{ item.1 }}-{{ item.0 }}-boot"
+  with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
+  when: 
+  - disk_type == "scsi"
+  - volume_type_id is defined
+
+- name: 'Create the control server with boot volume'
+  os_server:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    flavor: "{{ os_flavor_master }}"
+    boot_volume: "{{ item.1 }}-{{ item.0 }}-boot"
+    auto_ip: no
+    availability_zone: "{{ create_server_zone }}"
+    timeout: "{{ create_server_timeout|int * 60 }}" 
+    userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
+    nics:
+    - port-name: "{{ os_port_master }}-{{ item.0 }}"
+    meta: "{{ cluster_id_tag }}"
+    terminate_volume: True
+  with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
+  environment: 
+    PYTHONWARNINGS: 'ignore::UserWarning'
+  when:
+  - disk_type == "scsi"
+  - volume_type_id is defined

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-config/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-config/tasks/main.yaml
@@ -25,7 +25,7 @@
     src:  templates/install-config-yaml.j2
     dest: "install-config.yaml"
 
-- name: Configure Machine Network in Install Configuration
+- name: Configure machine network in install configuration
   script: tools/config-machine-network.py {{ sunbet_range.stdout_lines[0] }}
   args:
     executable: python3
@@ -47,7 +47,7 @@
       sed -i "s/cluster_name/{{ cluster_name }}/g" install-config.yaml
       cp -r install-config.yaml .install-config.yaml
      
-- name: Empty Compute Pools
+- name: Empty compute server pools
   script: tools/empty-compute-node.py
   args:
     executable: python3

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
@@ -10,15 +10,15 @@
 ---
 # tasks file for configure-install-ignition
 
-- name: Create Install Ignition Configs
+- name: Create install ignition configs
   command:
     cmd: ./openshift-install create ignition-configs
 
-- name: Export Infra ID
+- name: Export infra ID
   script: tools/infra-id.sh
   register: infra_id
 
-- name: Edit Bootstrap Ignition
+- name: Edit bootstrap ignition
   script: tools/ignition-modify.py
   args:
     executable: python3
@@ -26,26 +26,26 @@
 - name: 'Import common yaml'
   import_tasks: common.yaml
 
-- name: Upload Boostrap Ignition
+- name: Upload boostrap ignition
   command:
     cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw --container-format=bare --file bootstrap.ign "bootstrap-ignition-{{ infra_id.stdout_lines[0] }}"
 
-- name: Get Image Url
+- name: Get image url
   script: tools/get-image-path.sh "bootstrap-ignition-{{ infra_id.stdout_lines[0] }}"
   register: image_url
   
-- name: Get Glance Token
+- name: Get glance token
   command:
     cmd: openstack token issue -c id -f value
   register: glance_token
   
-- name: Generate Bootstrap Ignition Shim
+- name: Generate bootstrap ignition shim
   script: tools/generate-bootstrap-ignitionshim.py {{ image_url.stdout_lines[0] }} {{ glance_token.stdout }} {{ infra_id.stdout_lines[0] }}
   args:
     executable: python3
 
-- name: Generate Master Ignition
+- name: Generate master ignition
   script: tools/generate-master-ignition.sh {{ infra_id.stdout_lines[0] }} {{ os_control_nodes_number }}
 
-- name: Generate Worker Ignition
+- name: Generate worker ignition
   script: tools/generate-worker-ignition.sh {{ infra_id.stdout_lines[0] }} {{ os_compute_nodes_number }}

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-manifests/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-manifests/tasks/main.yaml
@@ -10,15 +10,15 @@
 ---
 # tasks file for configure-install-manifests
 
-- name: Create Install Manifests
+- name: Create install manifests
   command:
     cmd: ./openshift-install create manifests
 
-- name: Remove Machine and MachineSet
+- name: Remove machine and machineset
   shell:
     cmd: rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 
-- name: Make Control-plane Nodes Unschedulable
+- name: Make control-plane nodes unschedulable
   script: tools/make-control-plane-unschedulable.py
   args:
     executable: python3

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-and-image/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-and-image/tasks/main.yaml
@@ -10,7 +10,7 @@
 ---
 # tasks file for configure-installer-and-image
 
-- name: Download OpenShift Installer
+- name: Download openshift installer
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-install-linux.tar.gz
@@ -19,16 +19,16 @@
     group: root
     owner: root
 
-- name: Unzip OpenShift Installer
+- name: Unzip openshift installer
   command:
     cmd: tar -zvxf openshift-install-linux.tar.gz
   
-- name: Remove OpenShift Installer Archive
+- name: Remove openshift installer archive
   file:
     state: absent
     path: openshift-install-linux.tar.gz
 
-- name: Download OpenShift Client
+- name: Download openshift client
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-client-linux.tar.gz
@@ -37,21 +37,21 @@
     group: root
     owner: root
 
-- name: Unzip OpenShift Client Archive
+- name: Unzip openshift client archive
   command:
     cmd: tar -zvxf openshift-client-linux.tar.gz
   
-- name: Remove OpenShift Client Archive
+- name: Remove openshift client archive
   file:
     state: absent
     path: openshift-client-linux.tar.gz
 
-- name: Remove OpenShift RHCOS images
+- name: Remove openshift RHCOS images
   file:
     state: absent
     path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
     
-- name: Download RHCOS Image
+- name: Download RHCOS image
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz
@@ -63,7 +63,7 @@
   - vm_type == "zvm"
   - disk_type == "scsi"
 
-- name: Download RHCOS Image
+- name: Download RHCOS image
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz
@@ -75,32 +75,32 @@
   - vm_type == "zvm"
   - disk_type == "dasd"
 
-- name: Unzip RHCOS Image
+- name: Unzip RHCOS image
   command:
     cmd: gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
   when: 
   - vm_type == "zvm"
 
-- name: Upload RHCOS Image to ICIC Glance
+- name: Upload RHCOS image to ICIC glance
   command: 
     cmd: openstack image create --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
 
-- name: Upload RHCOS Image to ICIC Glance
+- name: Upload RHCOS image to ICIC glance
   command: 
     cmd: openstack image create --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
 
-- name: Remove OpenShift RHCOS images
+- name: Remove openshift RHCOS images
   file:
     state: absent
     path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
 
-- name: Download RHCOS Image
+- name: Download RHCOS image
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz
@@ -111,26 +111,26 @@
   when: 
   - vm_type == "kvm"
 
-- name: Unzip RHCOS Image
+- name: Unzip RHCOS image
   command:
     cmd: gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
   when: 
   - vm_type == "kvm"
 
-- name: Upload RHCOS Image to ICIC Glance
+- name: Upload RHCOS image to ICIC glance
   command: 
     cmd: openstack image create --disk-format=qcow2 --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2 rhcos
   when: 
   - vm_type == "kvm"
 
-- name: Remove Local RHCOS image
+- name: Remove local RHCOS image
   file:
     state: absent
     path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw
   when: 
   - vm_type == "zvm"
 
-- name: Remove Local RHCOS image
+- name: Remove local RHCOS image
   file:
     state: absent
     path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client/tasks/main.yaml
@@ -10,7 +10,7 @@
 ---
 # tasks file for configure-installer-and-image
 
-- name: Download OpenShift Installer
+- name: Download openshift installer
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-install-linux.tar.gz
@@ -19,16 +19,16 @@
     group: root
     owner: root
 
-- name: Unzip OpenShift Installer
+- name: Unzip openshift installer
   command:
     cmd: tar -zvxf openshift-install-linux.tar.gz
   
-- name: Remove OpenShift Installer Archive
+- name: Remove openshift installer archive
   file:
     state: absent
     path: openshift-install-linux.tar.gz
 
-- name: Download OpenShift Client
+- name: Download openshift client
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-client-linux.tar.gz
@@ -37,11 +37,11 @@
     group: root
     owner: root
 
-- name: Unzip OpenShift Client Archive
+- name: Unzip openshift client archive
   command:
     cmd: tar -zvxf openshift-client-linux.tar.gz
   
-- name: Remove OpenShift Client Archive
+- name: Remove openshift client archive
   file:
     state: absent
     path: openshift-client-linux.tar.gz

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
@@ -20,7 +20,7 @@
   - vm_type == "kvm"
   - disk_type == "scsi"
   
-- name: Download RHCOS Image
+- name: Download RHCOS image
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz
@@ -32,7 +32,7 @@
   - vm_type == "zvm"
   - disk_type == "scsi"
 
-- name: Download RHCOS Image
+- name: Download RHCOS image
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz
@@ -44,27 +44,27 @@
   - vm_type == "zvm"
   - disk_type == "dasd"
 
-- name: Unzip RHCOS Image
+- name: Unzip RHCOS image
   command:
     cmd: gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
   when: 
   - vm_type == "zvm"
 
-- name: Upload RHCOS Image to ICIC Glance
+- name: Upload RHCOS image to ICIC glance
   command: 
     cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
 
-- name: Upload RHCOS Image to ICIC Glance
+- name: Upload RHCOS image to ICIC glance
   command: 
     cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
 
-- name: Download RHCOS Image
+- name: Download RHCOS image
   become: yes
   get_url:
     url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz
@@ -75,26 +75,26 @@
   when: 
   - vm_type == "kvm"
 
-- name: Unzip RHCOS Image
+- name: Unzip RHCOS image
   command:
     cmd: gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
   when: 
   - vm_type == "kvm"
 
-- name: Upload RHCOS Image to ICIC Glance
+- name: Upload RHCOS image to ICIC glance
   command: 
     cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=qcow2 --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2 rhcos
   when: 
   - vm_type == "kvm"
 
-- name: Remove Local RHCOS image
+- name: Remove local RHCOS image
   file:
     state: absent
     path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw
   when: 
   - vm_type == "zvm"
 
-- name: Remove Local RHCOS image
+- name: Remove local RHCOS image
   file:
     state: absent
     path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
@@ -101,12 +101,12 @@
   when: (allocation_pool_start is not defined and allocation_pool_end is defined) or
         (allocation_pool_start is defined and allocation_pool_end is not defined)
 
-- name: 'Export Infra ID'
+- name: 'Export infra ID'
   shell:
     cmd: "jq -r .infraID metadata.json"
   register: infra_id
 
-- name: 'Generate random string for the Compute ports and store them in a json file'
+- name: 'Generate random string for the compute server ports and store them in a json file'
   script: tools/generate-random-compute-json.py {{ infra_id.stdout_lines[0] }} {{ os_compute_nodes_number }}
   args:
     executable: python3
@@ -123,7 +123,7 @@
   when:
   - auto_allocated_ip == false
 
-- name: 'Create the Control Plane ports'
+- name: 'Create the control server ports'
   os_port:
     name: "{{ item.1 }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
@@ -136,7 +136,7 @@
   when:
   - auto_allocated_ip == false
 
-- name: 'Create the Compute ports'
+- name: 'Create the compute server ports'
   os_port:
     name: "{{ item.1  }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
@@ -159,7 +159,7 @@
   - auto_allocated_ip == true
 
 
-- name: 'Create the Control Plane ports'
+- name: 'Create the control server ports'
   os_port:
     name: "{{ item.1 }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
@@ -169,7 +169,7 @@
   when:
   - auto_allocated_ip == true
 
-- name: 'Create the Compute ports'
+- name: 'Create the compute server ports'
   os_port:
     name: "{{ item.1 }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
@@ -183,12 +183,12 @@
   command:
     cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_bootstrap }}"
 
-- name: 'Set Control Plane ports tag'
+- name: 'Set control server ports tag'
   command:
     cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
   with_indexed_items: "{{ [os_port_master] * os_control_nodes_number }}"
 
-- name: 'Set Compute ports tag'
+- name: 'Set compute server ports tag'
   command:
     cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
   with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-pre-check/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-pre-check/tasks/main.yaml
@@ -88,3 +88,27 @@
   fail:
     msg: "Server group number is not enough, current: {{ server_group.stdout_lines[0] }}, required: 1"
   failed_when: "server_group.stdout_lines[0]|int < 1"
+
+- name: Get storage provider
+  shell: openstack volume service list -f csv | grep cinder-volume |grep -E 'enabled|up' |head -n1|awk -F , '{print$4$5}' |tr -d '"'
+  register: storage_backend
+  when:  
+  - volume_type_id is defined
+  - disk_type == "scsi"
+
+- name: Get storage template
+  shell: openstack volume type list -c ID -f value | grep {{ volume_type_id }} | wc -l
+  register: storage_template
+  when:  
+  - volume_type_id is defined
+  - disk_type == "scsi"
+
+- name: Check if storage provider is configured
+  fail:
+    msg: "Storage provider is not enabled and active."
+  failed_when:  volume_type_id is defined and storage_backend.stdout != 'enabledup' 
+
+- name: Check storage template
+  fail:
+    msg: "Storage template is not configured correctly."
+  failed_when: volume_type_id is defined and storage_template.stdout |int < 1  


### PR DESCRIPTION
This PR contains below changes:
1) add `volume_type_id` when creating virtual machine with boot volume
2) change all tasks name

Verified three situations on zvm test stand:
1) disk_type=scsi and volume_type_id=XXXXX
1.1) add new compute node
2) disk_type=scsi
2.1) add new compute node
3) disk_type=dasd
