### PR TITLE
[cloud_infra_center] remove root user limit

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -138,14 +138,13 @@ sudo dnf install redhat-rpm-config gcc libffi-devel python3-devel openssl-devel 
 ```
 Then create the requirements file and use pip3 to install the python modules:
 
-**Note**: The requirements.txt are tested for python-openstackclient =5.5.0.
+**Note**: The requirements.txt are tested for python-openstackclient=5.5.0.
 ```sh
 cat <<'EOF' >> requirements.txt 
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
-
 cliff>=3.5.0 # Apache-2.0
 iso8601>=0.1.11 # MIT
 openstacksdk>=0.57.0 # Apache-2.0
@@ -156,9 +155,8 @@ python-keystoneclient>=3.22.0 # Apache-2.0
 python-novaclient>=17.0.0 # Apache-2.0
 python-cinderclient>=3.3.0 # Apache-2.0
 stevedore>=2.0.1 # Apache-2.0
-openstacksdk==0.57.0
-netaddr==0.8.0
-python-openstackclient==5.2.0
+netaddr>=0.8.0
+python-openstackclient>=5.5.0
 EOF
 
 sudo pip3 install -r requirements.txt python-openstackclient --ignore-installed
@@ -248,8 +246,8 @@ Update your settings based on the samples. The following propeties are **require
 | `use_network_subnet` | \<subnet id from network name in icic\> |`openstack network list -c Subnets -f value`|
 | `vm_type` | kvm| The operation system of OpenShift Container Platform, <br>supported: `kvm` or `zvm`| |
 | `disk_type` | dasd|The disk storage of OpenShift Container Platform, <br>supported: `dasd` or `scsi` | |
-| `openshift_version` |4.10| The product version of OpenShift Container Platform, <br>such as `4.6` or `4.7` or `4.8`| |
-| `openshift_minor_version` |3| The minor version of Openshift Container Platform, <br>such as `7` or `13` | 
+| `openshift_version` |4.10| The product version of OpenShift Container Platform, <br>such as `4.6` or `4.7` or `4.8`. <br> And the rhcos is not updated for every single minor version. User can get available openshift_version from [here](https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/)| |
+| `openshift_minor_version` |3| The minor version of Openshift Container Platform, <br>such as `3`.  <br>For openshift_version `4.10` for example, the only rhcos release available is `4.10.3`, and user can inspect what minor releases are available by checking [here](https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.10/) to see whats there | 
 | `auto_allocated_ip` |true|(Boolean) true or false, if false, <br>IPs will be allocated from `allocation_pool_start` and `allocation_pool_end` |
 | `os_flavor_bootstrap` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB  | |
 | `os_flavor_master` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB | |

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-and-image/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-and-image/tasks/main.yaml
@@ -13,11 +13,9 @@
 - name: Download openshift installer
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-install-linux.tar.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-install-linux.tar.gz
     dest: .
     mode: 0755
-    group: root
-    owner: root
 
 - name: Unzip openshift installer
   command:
@@ -31,11 +29,9 @@
 - name: Download openshift client
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-client-linux.tar.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-client-linux.tar.gz
     dest: .
     mode: 0755
-    group: root
-    owner: root
 
 - name: Unzip openshift client archive
   command:
@@ -54,11 +50,9 @@
 - name: Download RHCOS image
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz
     dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
     mode: 0755
-    group: root
-    owner: root
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
@@ -66,11 +60,9 @@
 - name: Download RHCOS image
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz
     dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
     mode: 0755
-    group: root
-    owner: root
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
@@ -103,11 +95,9 @@
 - name: Download RHCOS image
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz
     dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
     mode: 0755
-    group: root
-    owner: root
   when: 
   - vm_type == "kvm"
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client/tasks/main.yaml
@@ -13,11 +13,9 @@
 - name: Download openshift installer
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-install-linux.tar.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-install-linux.tar.gz
     dest: .
     mode: 0755
-    group: root
-    owner: root
 
 - name: Unzip openshift installer
   command:
@@ -31,11 +29,9 @@
 - name: Download openshift client
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-client-linux.tar.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-client-linux.tar.gz
     dest: .
     mode: 0755
-    group: root
-    owner: root
 
 - name: Unzip openshift client archive
   command:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
@@ -23,11 +23,9 @@
 - name: Download RHCOS image
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz
     dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
     mode: 0755
-    group: root
-    owner: root
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
@@ -35,11 +33,9 @@
 - name: Download RHCOS image
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz
     dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
     mode: 0755
-    group: root
-    owner: root
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
@@ -67,11 +63,9 @@
 - name: Download RHCOS image
   become: yes
   get_url:
-    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz
     dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
     mode: 0755
-    group: root
-    owner: root
   when: 
   - vm_type == "kvm"
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
@@ -62,42 +62,37 @@
     msg: "use_network_subnet is not defined!"
   failed_when: use_network_subnet is not defined
 
-- name: "Get subnet name of subnet {{ use_network_subnet }}"
-  command:
-    cmd: "openstack subnet show {{ use_network_subnet }} -c name -f value"
-  register: os_subnet_name
-
-- name: "Get first start of allocation pool of subnet {{ os_subnet_name.stdout }}"
+- name: "Get first start of allocation pool of subnet {{ use_network_subnet }}"
   shell: |
-     openstack subnet show {{ os_subnet_name.stdout }} -c allocation_pools -f json | grep start | awk -F ':' '{print$2}'|tr -d '",'
+     openstack subnet show {{ use_network_subnet }} -c allocation_pools -f json | grep start | awk -F ':' '{print$2}'|tr -d '",'
   register: default_allocation_pool_start
 
-- name: "Get first end of allocation pool of subnet {{ os_subnet_name.stdout }}"
+- name: "Get first end of allocation pool of subnet {{ use_network_subnet }}"
   shell: |
-     openstack subnet show {{ os_subnet_name.stdout }} -c allocation_pools -f json | grep end | awk -F ':' '{print$2}'|tr -d '",'
+     openstack subnet show {{ use_network_subnet }} -c allocation_pools -f json | grep end | awk -F ':' '{print$2}'|tr -d '",'
   register: default_allocation_pool_end
 
-- name: "Remove all DNS nameserver of subnet {{ os_subnet_name.stdout }}"
+- name: "Remove all DNS nameserver of subnet {{ use_network_subnet }}"
   command:
-    cmd: "openstack subnet set --no-dns-nameservers {{ os_subnet_name.stdout }} "
+    cmd: "openstack subnet set --no-dns-nameservers {{ use_network_subnet }} "
 
-- name: 'Update new DNS nameserver and allocation pool of subnet {{ os_subnet_name.stdout }}'
+- name: 'Update new DNS nameserver and allocation pool of subnet {{ use_network_subnet }}'
   command:
-    cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} {{ os_subnet_name.stdout }}"
+    cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} {{ use_network_subnet }}"
   when:
   - allocation_pool_start is defined
   - allocation_pool_end is defined 
 
-- name: 'Update new DNS nameserver of subnet {{ os_subnet_name.stdout }}'
+- name: 'Update new DNS nameserver of subnet {{ use_network_subnet }}'
   command:
-    cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} {{ os_subnet_name.stdout }}"
+    cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} {{ use_network_subnet }}"
   when:
   - allocation_pool_start is not defined
   - allocation_pool_end is not defined 
 
-- name: 'Update new DNS nameserver and partial allocation pool of subnet {{ os_subnet_name.stdout }}'
+- name: 'Update new DNS nameserver and partial allocation pool of subnet {{ use_network_subnet }}'
   command:
-    cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} --allocation-pool start={{ allocation_pool_start | default(sunbet_range.stdout_lines[0] | next_nth_usable(10)) }},end={{ allocation_pool_end | default(os_subnet_range | ipaddr('last_usable')) }} {{ os_subnet_name.stdout }}"
+    cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} --allocation-pool start={{ allocation_pool_start | default(sunbet_range.stdout_lines[0] | next_nth_usable(10)) }},end={{ allocation_pool_end | default(os_subnet_range | ipaddr('last_usable')) }} {{ use_network_subnet }}"
   when: (allocation_pool_start is not defined and allocation_pool_end is defined) or
         (allocation_pool_start is defined and allocation_pool_end is not defined)
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-pre-check/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-pre-check/tasks/main.yaml
@@ -90,7 +90,7 @@
   failed_when: "server_group.stdout_lines[0]|int < 1"
 
 - name: Get storage provider
-  shell: openstack volume service list -f csv | grep cinder-volume |grep -E 'enabled|up' |head -n1|awk -F , '{print$4$5}' |tr -d '"'
+  shell: openstack volume service list -f csv | grep cinder-volume | wc -l
   register: storage_backend
   when:  
   - volume_type_id is defined
@@ -106,7 +106,7 @@
 - name: Check if storage provider is configured
   fail:
     msg: "Storage provider is not enabled and active."
-  failed_when:  volume_type_id is defined and storage_backend.stdout != 'enabledup' 
+  failed_when:  volume_type_id is defined and storage_backend.stdout |int < 1 
 
 - name: Check storage template
   fail:


### PR DESCRIPTION
This PR contains some changes.
1) Remove the root user and group when downloading IMAGE and BINARY
2) Change the hard code s390x architecture
3) Remove to get subnet name when modify network
4) Doc update

I've tested the non-user `demo` to deploy UPI, here is some key comments.
- Login your ansible linux server
- useradd demo
- passwd demo
- usermod -G icic-filter demo
- sudo visudo , and add user's permission `demo  ALL=(ALL) NOPASSWD:ALL`
- following guide to download code and run playbook
- run `01-preparation.yaml` as `demo` user
- run `bastion.yaml` as `root` user because this playbook needs to configure DNS and HAPROXY in your root system
-  run `02-create-cluster-control.yaml`
```
time="2022-06-21T03:38:11-04:00" level=debug msg="Bootstrap status: complete"
time="2022-06-21T03:38:11-04:00" level=info msg="It is now safe to remove the bootstrap resources"
time="2022-06-21T03:38:11-04:00" level=debug msg="Time elapsed per stage:"
time="2022-06-21T03:38:11-04:00" level=debug msg="Bootstrap Complete: 7m27s"
time="2022-06-21T03:38:11-04:00" level=info msg="Time elapsed: 7m27s"

[demo@rhel85 ocp_upi]$ ./oc get nodes
NAME                       STATUS   ROLES    AGE     VERSION
openshift-j2bnx-master-0   Ready    master   19m     v1.23.3+e419edf
openshift-j2bnx-master-1   Ready    master   9m55s   v1.23.3+e419edf
openshift-j2bnx-master-2   Ready    master   15m     v1.23.3+e419edf
[demo@rhel85 ocp_upi]$
```
