### PR TITLE
Add private registry support for installs

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/99-just-downloads.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/99-just-downloads.yaml
@@ -27,18 +27,4 @@
 # - Add more playbooks
 
 ---
-- import_playbook: configure-pre-check.yaml
-- import_playbook: configure-installer-client.yaml
-  when: use_localreg == false 
-- import_playbook: configure-installer-client-local.yaml
-  when: use_localreg == true
-- import_playbook: configure-install-config.yaml
-- import_playbook: configure-install-manifests.yaml
-- import_playbook: configure-install-ignition.yaml
-- import_playbook: configure-installer-rhcos.yaml
-  when: use_localreg == false
-- import_playbook: configure-installer-rhcos-local.yaml
-  when: use_localreg == true
-- import_playbook: configure-security-groups.yaml
-- import_playbook: configure-network.yaml
-- import_playbook: configure-bastion-properties.yaml
+- import_playbook: just-downloads.yaml

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-installer-client-local.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-installer-client-local.yaml
@@ -1,0 +1,14 @@
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+---
+- name: Download openshift installer client from local mirror
+  hosts: localhost
+  roles:
+  - configure-installer-client-local

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-installer-rhcos-local.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/configure-installer-rhcos-local.yaml
@@ -1,0 +1,14 @@
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+---
+- name: Download openshift RHCOS image from local mirror
+  hosts: localhost
+  roles:
+  - configure-installer-rhcos-local

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -64,6 +64,45 @@ all:
       #https_proxy: '<https-proxy>'
       #no_proxy: '<no-proxy>'
 
+      use_localreg: false # true or false
+      #localreg_mirror: "intreg0.fpet.pokprv.stglabs.ibm.com:5000/ocp4/openshift4"
+      #localreg_source1: "quay.io/openshift-release-dev/ocp-release"
+      #localreg_source2: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
+      #localreg_media: "http://fpetutil.fpet.pokprv.stglabs.ibm.com/lzocpc"
+
+      #additional_certs: |
+      #  additionalTrustBundle: |
+      #    -----BEGIN CERTIFICATE-----
+      #    MIIEuzCCAyOgAwIBAgIBATANBgkqhkiG9w0BAQsFADBGMSQwIgYDVQQKDBtGUEVU
+      #    LlBPS1BSVi5TVEdMQUJTLklCTS5DT00xHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1
+      #    dGhvcml0eTAeFw0yMTA4MTYxNTA2MjJaFw00MTA4MTYxNTA2MjJaMEYxJDAiBgNV
+      #    BAoMG0ZQRVQuUE9LUFJWLlNUR0xBQlMuSUJNLkNPTTEeMBwGA1UEAwwVQ2VydGlm
+      #    aWNhdGUgQXV0aG9yaXR5MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEA
+      #    58r05eSLyAlHWu2mMtXUPRareADrIKfumz6O9YSrcxXXXs21P5YsIVMMi79v9DOi
+      #    LWyVdIQ5sX8ABSkIFmvyR0+uryd7zOlFuZJ34eIyQ8hJJVcmIJw+3n8x8sa0HbZ8
+      #    ao3OZz3YrM1svAey4XBINl9won50lrx8asbRC29EJtPE6URrB4qO6Fenx9IZ67nW
+      #    GC8KeXSTliX161PS7JNDcQOb5obtIP7SGjsCVL5xXVfrSPzcc6Kbg1soErpVTJ1u
+      #    ZqI5Bg35duVUdq8nyFNcpPZ0bJcIyT7eN11oh50/gzDc7bgnp2RJJosPl+FDEEXZ
+      #    44QxnioHOiRIngUkCM7dDgrPjdq2PCTiw+YykmR6KThdm0bnZ81Nyso/9CEnWZqU
+      #    DYpbSnO6Gkz/aTdxAZ9b0jKxlsDuPRH0yHUuNCsecUadeOazQyHvr3mecaOCxc2E
+      #    vPLrj8T01n6Un5n1K3AgZ9Qtp3DzxvQmhkBLe183V870FMYnzoVE2R5p9Tanztqb
+      #    AgMBAAGjgbMwgbAwHwYDVR0jBBgwFoAUWl1Gycb6XU6QdKILW25GCvvciRAwDwYD
+      #    VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAcYwHQYDVR0OBBYEFFpdRsnG+l1O
+      #    kHSiC1tuRgr73IkQME0GCCsGAQUFBwEBBEEwPzA9BggrBgEFBQcwAYYxaHR0cDov
+      #    L2lwYS1jYS5mcGV0LnBva3Bydi5zdGdsYWJzLmlibS5jb20vY2Evb2NzcDANBgkq
+      #    hkiG9w0BAQsFAAOCAYEA545ByUeL8jtRnfGrqQQJuRE/+exUe+/e4sWzASHC6Z/z
+      #    y0rjcM5dMdNYTGiy2lidF4lcBV0mTc28ubO0vZ68MzH4uYT4KObsC0e4xxKO2EH6
+      #    6RL6oJ9f2zKpOu28fcyKRjA74OLb+69354Qpr8TmQhkWRb7tE9hj1OQHrj+uJG+l
+      #    CQzvAKxDBYWqDwAkWhsBXi/EBesCkCXoJDlyE9my8eAndUOLRNDqlFZJPDuasJrZ
+      #    EdQJie9exU+CU1+Hm0oQH3HWsfvSgg/vAUk9MXrTxets0eVY22G5kZKSZvSnN9A7
+      #    oL8PNCuq3BZleSNxgeovoBp3mIMrFfwHIRwu8EL3CeFecV6wOaZrFBRU938mLwVa
+      #    RPPm1I4wxEnqSn9yqLkBiFGbb0o5ELfGMv2zHGiR+wHGYbelbS2ewCLgo/+w690E
+      #    rtlwkB3+yU4Qwld+BiRSb84CvGufVSeZ2abPk7Kf67fLRfKtIHza4hzJwpo6z4wq
+      #    bRaUkgKe6w4n+XYm7WGg
+      #    -----END CERTIFICATE-----
+
+
+
       approve_nodes_csr: 10 # minute
       create_server_timeout: 10 # minute
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/just-downloads.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/just-downloads.yaml
@@ -1,0 +1,14 @@
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+---
+- name: Download OCP components for isolated network install
+  hosts: localhost
+  roles:
+  - just-downloads

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-config/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-config/tasks/main.yaml
@@ -40,6 +40,23 @@
   when:
   - use_proxy == true 
     
+- name: Add local registry info in install-config.yaml
+  shell:
+    cmd: |
+      sed -i '/baseDomain/a imageContentSources:' install-config.yaml
+      sed -i '/imageContentSources/a - mirrors:\n\ \ - {{ localreg_mirror }}\n\ \ source: {{ localreg_source2 }} ' install-config.yaml
+      sed -i '/imageContentSources/a - mirrors:\n\ \ - {{ localreg_mirror }}\n\ \ source: {{ localreg_source1 }} ' install-config.yaml
+  when:
+  - use_localreg == true
+
+- name: Add additional certificates to install-config.yaml
+  lineinfile:
+    line: '{{ additional_certs }}'
+    path: install-config.yaml
+    insertafter: EOF
+  when: additional_certs is defined
+
+    
 - name: Update cluster domain name in install-config.yaml
   shell: 
     cmd: |

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client-local/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client-local/tasks/main.yaml
@@ -1,0 +1,38 @@
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+---
+# tasks file for configure-installer-and-image
+
+- name: Download openshift installer
+  #  become: yes
+  get_url:
+    url: '{{ localreg_media }}/openshift-install'
+    dest: .
+    mode: 0755
+    #group: root
+    #owner: root
+
+- name: Download openshift client
+  #become: yes
+  get_url:
+    url: '{{ localreg_media }}/openshift-client-linux.tar.gz'
+    dest: .
+    mode: 0644
+    #group: root
+    #owner: root
+
+- name: Unzip openshift client archive
+  command:
+    cmd: tar -zvxf openshift-client-linux.tar.gz
+  
+- name: Remove openshift client archive
+  file:
+    state: absent
+    path: openshift-client-linux.tar.gz

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
@@ -1,0 +1,102 @@
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+---
+# tasks file for configure-installer-and-image
+
+- name: 'Import common yaml'
+  import_tasks: common.yaml
+
+- name: Check if kvm is scsi disk
+  fail:
+    msg: "kvm does not support scsi disk type"
+  failed_when: 
+  - vm_type == "kvm"
+  - disk_type == "scsi"
+  
+- name: Download RHCOS image
+  #become: yes
+  get_url:
+    url: '{{ localreg_media }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz'
+    dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+    mode: 0644
+    #group: root
+    #owner: root
+  when: 
+  - vm_type == "zvm"
+  - disk_type == "scsi"
+
+- name: Download RHCOS image
+  #become: yes
+  get_url:
+    url: '{{ localreg_media }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz'
+    dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+    mode: 0644
+    #group: root
+    #owner: root
+  when: 
+  - vm_type == "zvm"
+  - disk_type == "dasd"
+
+- name: Unzip RHCOS image
+  command:
+    cmd: gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+  when: 
+  - vm_type == "zvm"
+
+- name: Upload RHCOS image to ICIC glance
+  command: 
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
+  when: 
+  - vm_type == "zvm"
+  - disk_type == "scsi"
+
+- name: Upload RHCOS image to ICIC glance
+  command: 
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
+  when: 
+  - vm_type == "zvm"
+  - disk_type == "dasd"
+
+- name: Download RHCOS image
+  #become: yes
+  get_url:
+    url: '{{ localreg_media }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz'
+    dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
+    mode: 0644
+    #group: root
+    #owner: root
+  when: 
+  - vm_type == "kvm"
+
+- name: Unzip RHCOS image
+  command:
+    cmd: gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
+  when: 
+  - vm_type == "kvm"
+
+- name: Upload RHCOS image to ICIC glance
+  command: 
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=qcow2 --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2 rhcos
+  when: 
+  - vm_type == "kvm"
+
+- name: Remove local RHCOS image
+  file:
+    state: absent
+    path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw
+  when: 
+  - vm_type == "zvm"
+
+- name: Remove local RHCOS image
+  file:
+    state: absent
+    path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2
+  when: 
+  - vm_type == "kvm"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/just-downloads/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/just-downloads/tasks/main.yaml
@@ -1,0 +1,73 @@
+# =================================================================
+# Licensed Materials - Property of IBM
+#
+# (c) Copyright IBM Corp. 2021 All Rights Reserved
+#
+# US Government Users Restricted Rights - Use, duplication or
+# disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+# =================================================================
+
+---
+# tasks file for configure-installer-and-image
+
+- name: Download openshift installer
+  #  become: yes
+  get_url:
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-install-linux.tar.gz
+    dest: .
+    mode: 0644
+    #group: root
+    #owner: root
+
+- name: Download openshift client
+  #become: yes
+  get_url:
+    url: https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/openshift-client-linux.tar.gz
+    dest: .
+    mode: 0644
+    #group: root
+    #owner: root
+
+# tasks file for configure-installer-and-image
+
+- name: Check if kvm is scsi disk
+  fail:
+    msg: "kvm does not support scsi disk type"
+  failed_when: 
+  - vm_type == "kvm"
+  - disk_type == "scsi"
+  
+- name: Download RHCOS image
+  #become: yes
+  get_url:
+    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz
+    dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+    mode: 0644
+    #group: root
+    #owner: root
+  when: 
+  - vm_type == "zvm"
+  - disk_type == "scsi"
+
+- name: Download RHCOS image
+  #become: yes
+  get_url:
+    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz
+    dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+    mode: 0644
+    #group: root
+    #owner: root
+  when: 
+  - vm_type == "zvm"
+  - disk_type == "dasd"
+
+- name: Download RHCOS image
+  #become: yes
+  get_url:
+    url: https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz
+    dest: ./rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
+    mode: 0644
+    #group: root
+    #owner: root
+  when: 
+  - vm_type == "kvm"


### PR DESCRIPTION
this is a set of changes to allow OCP installs on private disconnected networks from a local OCP mirror registry