### PR TITLE
z trial playbook edits to data set basics and submit query retrieve

### DIFF
--- a/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
+++ b/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
@@ -21,8 +21,7 @@
 # Configure:
 #   tgt_tmp_dir - this is the USS directory on the target which will be written
 #                 to for this example.
-#   ctl_tmp_dir - this is the directory on the controller which will be written
-#                 to for this example.
+#
 # Optional:
 #   data_set_name - this is the data set name that will be created during
 #                   execution of this sample.
@@ -39,7 +38,6 @@
   gather_facts: no
   vars:
     tgt_tmp_dir: "/tmp"
-    ctl_tmp_dir: "/tmp"
   environment: "{{ environment_vars }}"
 
   tasks:

--- a/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
+++ b/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
@@ -44,7 +44,7 @@
 
   tasks:
     # ##########################################################################
-    # Generate a temporary data set name
+    # Generate and set temporary names for data sets
     # ##########################################################################
     - name: Create temp sequential data set name
       command: "mvstmp {{ ansible_user | upper }}"
@@ -54,29 +54,16 @@
       command: "mvstmp {{ ansible_user | upper }}"
       register: tmp_ds_pds
 
-    # ##########################################################################
-    # Fact setting for use by this playbook
-    # ##########################################################################
-    - name: Setting fact `data_set_name` for use by this sample
+    - name: Set names for sequential data set and pds for use by this sample
       set_fact:
         data_set_name: "{{ tmp_ds_seq.stdout }}"
         pds_name: "{{ tmp_ds_pds.stdout }}"
 
-    - name: Fact `data_set_name` set with value
+    - name: Fact `data_set_name` and `pds_name` set with values
       debug:
-        msg: "{{ data_set_name }}"
-
-    - name: Detecting system name
-      command: uname -n
-      register: result
-
-    - name: Setting fact `system_name` for use by this sample
-      set_fact:
-        system_name: "{{ result.stdout }}"
-
-    - name: Fact `system_name` set with value
-      debug:
-        msg: "{{ system_name }}"
+        msg:
+          - "sequential data set name - {{ data_set_name }}"
+          - "pds name - {{ pds_name }}"
 
     ############################################################################
     # Modules zos_data_set, zos_fetch

--- a/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
+++ b/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
@@ -100,7 +100,6 @@
         format: fb
         record_length: 100
         size: 5M
-        volume: dimato
       register: result
 
     - name: Response for data set creation
@@ -117,9 +116,10 @@
       debug:
         msg: "{{ result }}"
 
-    - zos_copy:
+    - name: zos_copy
+      zos_copy:
         src: "{{ playbook_dir }}/files/HELLO.jcl"
-        dest: "/tmp/HELLO"
+        dest: "{{ tgt_tmp_dir }}/HELLO"
        #remote_src: yes
       register: result
 

--- a/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
+++ b/zos_concepts/data_sets/data_set_basics/data_set_basics.yml
@@ -50,7 +50,7 @@
       command: "mvstmp {{ ansible_user | upper }}"
       register: tmp_ds_seq
 
-    - name: Create temp sequential data set name
+    - name: Create temp PDS name
       command: "mvstmp {{ ansible_user | upper }}"
       register: tmp_ds_pds
 

--- a/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
+++ b/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
@@ -1,5 +1,5 @@
 ###############################################################################
-# © Copyright IBM Corporation 2020, 2021
+# © Copyright IBM Corporation 2020, 2021, 2022
 ###############################################################################
 
 ###############################################################################
@@ -15,21 +15,17 @@
 #
 #  Additional facts for this playbook can be configured to override the defaults
 #  by reviewing the "Fact setting" section of this playbook, for example,
-#  `data_set_name` and `system_name`.
+#  `data_set_name`.
 #
 # Requirements:
-#   IBM z/OS core collection 1.1.0 or later
+#   IBM z/OS core collection 1.1.0 or later # FIXME - update to correct version.
 #
 # Configure:
 #   tgt_tmp_dir - this is the USS directory on the target which will be written
 #                 to for this example.
-#   ctl_tmp_dir - this is the directory on the controller which will be written
-#                 to for this example.
 # Optional:
 #   data_set_name - this is the data set name that will be created during
 #                   execution of this sample.
-#   system_name - this is the system name that will be used during this example,
-#                 determined by executing `uname -n` on the target.
 #   job_name - this is the job name what will be used in this sample, if you
 #              change the HELLO.JCL job name, you must update this variable
 ###############################################################################
@@ -41,7 +37,6 @@
   gather_facts: no
   vars:
     tgt_tmp_dir: "/tmp"
-    ctl_tmp_dir: "/tmp"
     job_name: "HELLO"
   environment: "{{ environment_vars }}"
 
@@ -53,32 +48,16 @@
       command: "mvstmp {{ ansible_user | upper }}"
       register: tmp_ds
 
-    - set_fact:
-        tmp_data_set: "{{ tmp_ds.stdout }}"
-
     # ##########################################################################
     # Fact setting for use by this playbook
     # ##########################################################################
     - name: Setting fact `data_set_name` for use by this sample
       set_fact:
-        data_set_name: "{{ tmp_data_set }}"
+        data_set_name: "{{ tmp_ds.stdout }}"
 
     - name: Fact `data_set_name` set with value
       debug:
         msg: "{{ data_set_name }}"
-
-    - name: Detecting system name
-      #shell: "uname -a |awk '{print $2}'"
-      command: uname -n
-      register: result
-
-    - name: Setting fact `system_name` for use by this sample
-      set_fact:
-        system_name: "{{ result.stdout }}"
-
-    - name: Fact `system_name` set with value
-      debug:
-        msg: "{{ system_name }}"
 
     ############################################################################
     # Modules zos_data_set, zos_tso_command, zos_job_submit, zos_job_query,
@@ -216,20 +195,20 @@
     # +-------------------------------------------------------------------------
 
     - name: Create directory {{ tgt_tmp_dir }}/ansible/jcl on USS
-            target {{ system_name }}
+            target
       file:
         path: "{{ tgt_tmp_dir }}/ansible/jcl"
         state: directory
 
     - name: Write sample {{ job_name }} JCL in {{ tgt_tmp_dir }}/ansible/jcl
             on USS
-            target {{ system_name }}
+            target
       shell: "echo {{ lookup('file', playbook_dir + '/files/{{job_name}}.jcl') | quote }} > {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
       changed_when: true
       register: result
 
     - name: Response for write sample {{job_name}} JCL in {{ tgt_tmp_dir }}/ansible/jcl
-            on USS target {{ system_name }}
+            on USS target
       debug:
         msg: "{{ result }}"
 
@@ -245,32 +224,32 @@
       debug:
         msg: "{{ result }}"
 
-    - name: Query the submitted job {{job_name}} on USS target {{ system_name }}
+    - name: Query the submitted job {{job_name}} on USS target
       zos_job_query:
         job_name: "{{job_name}}"
       register: result
 
     - name: Response for Query the submitted job {{job_name}}
-            on USS target {{ system_name }}
+            on USS target
       debug:
         msg: "{{ result }}"
 
-    - name: Get {{job_name}} job output on USS target {{ system_name }}
+    - name: Get {{job_name}} job output on USS target
       zos_job_output:
         job_name: "{{job_name}}"
       register: result
 
-    - name: Response for Get {{job_name}} job output on USS target {{ system_name }}
+    - name: Response for Get {{job_name}} job output on USS target
       debug:
         msg: "{{ result }}"
 
-    - name: Remove {{job_name}} JCL and folder on USS target {{ system_name }}
+    - name: Remove {{job_name}} JCL and folder on USS target
       file:
         path: "{{ tgt_tmp_dir }}/ansible"
         state: absent
 
     - name: Response for remove {{job_name}} JCL and folder on
-            USS target {{ system_name }}
+            USS target
       debug:
         msg: "{{ result }}"
 

--- a/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
+++ b/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
@@ -64,9 +64,9 @@
     # zos_job_output
     ############################################################################
     # +-------------------------------------------------------------------------
-    # | Create a data set, create JCL on USS target, copy USS JCL to data set,
-    # | rename data set using TSO commands, submit JCL in data set, query job,
-    # | get job output, delete data set using TSO command
+    # | Create a data set and member, create JCL on USS target, copy USS JCL to
+    # | data set, rename data set using TSO commands, submit JCL in data set,
+    # | query job, get job output.
     # +-------------------------------------------------------------------------
     - name: Create a PDS data set {{ data_set_name }}
       zos_data_set:
@@ -82,6 +82,13 @@
       debug:
         msg: "{{ result }}"
 
+    # +-------------------------------------------------------------------------
+    # | "with_sequence" is a type of Ansible loop. The loop here only runs for a
+    # | single iteration and is included solely to demonstrate how easy and
+    # | straightforward it would be to perform the operation for multiple
+    # | members. The end result of this block is a single member 'MEM1' is 
+    # | created.
+    # +-------------------------------------------------------------------------
     - name: Create a PDS member and replace if member exist
       zos_data_set:
         name: "{{ data_set_name }}(MEM{{ item }})"
@@ -101,8 +108,10 @@
 
     - name: Write HELLO JCL to USS in {{ tgt_tmp_dir }}/ansible/jcl/HELLO"
         on target {{ inventory_hostname }}
-      shell: "echo {{ lookup('file', playbook_dir + '/files/HELLO.jcl') | quote }} > {{ tgt_tmp_dir }}/ansible/jcl/HELLO"
-      changed_when: true
+      zos_copy:
+        src: "{{ playbook_dir }}/files/HELLO.jcl"
+        dest: "{{ tgt_tmp_dir }}/ansible/jcl/HELLO"
+      # changed_when: true
       register: result
 
     - name: Response for write HELLO JCL to USS
@@ -111,10 +120,12 @@
       debug:
         msg: "{{ result }}"
 
-    - name: Populate {{ data_set_name }} member with data from USS file in
+    - name: Populate {{ data_set_name }} member with data from USS file
         in {{ tgt_tmp_dir }}/ansible/jcl
-      command: 'cp {{ tgt_tmp_dir }}/ansible/jcl/HELLO "//''{{ data_set_name }}(MEM{{ item }})''"'
-      with_sequence: count=1
+      zos_copy:
+        src: "{{ tgt_tmp_dir }}/ansible/jcl/HELLO"
+        remote_src: True
+        dest: "{{ data_set_name }}(MEM1)"
       register: result
 
     - name: Response for populate {{ data_set_name }} member with data from
@@ -167,45 +178,10 @@
       debug:
         msg: "{{ result }}"
 
-    - name: TSO command delete data set {{ data_set_name }}.LLQ
-      zos_tso_command:
-        commands:
-          - DELETE '{{ data_set_name }}.LLQ'
-      register: result
-
-    - name: Response for TSO command delete data set {{ data_set_name }}.LLQ
-      debug:
-        msg: "{{ result }}"
-
-    - name: Remove files on target in {{ tgt_tmp_dir }}/ansible
-      file:
-        path: "{{ tgt_tmp_dir }}/ansible"
-        state: absent
-      register: result
-
-    - name: Response for remove files on target in {{ tgt_tmp_dir }}/ansible
-      debug:
-        msg: "{{ result }}"
-
-
     # +-------------------------------------------------------------------------
-    # | Create a directory in USS on the target, write sample JCL on target,
-    # | submit the target JCL, query for the submitted job and obtain the
-    # | job output, demonstrate creating and deleting data sets
+    # | Submit target JCL from USS, query for the submitted job and obtain the
+    # | job output, cleanup USS files and data sets.
     # +-------------------------------------------------------------------------
-
-    - name: Create directory {{ tgt_tmp_dir }}/ansible/jcl on USS
-            target
-      file:
-        path: "{{ tgt_tmp_dir }}/ansible/jcl"
-        state: directory
-
-    - name: Write sample {{ job_name }} JCL in {{ tgt_tmp_dir }}/ansible/jcl
-            on USS
-            target
-      shell: "echo {{ lookup('file', playbook_dir + '/files/{{job_name}}.jcl') | quote }} > {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
-      changed_when: true
-      register: result
 
     - name: Response for write sample {{job_name}} JCL in {{ tgt_tmp_dir }}/ansible/jcl
             on USS target
@@ -255,7 +231,7 @@
 
     - name: Delete data set {{ data_set_name }}
       zos_data_set:
-        name: "{{ data_set_name }}"
+        name: "{{ data_set_name }}.LLQ"
         state: absent
       register: result
 

--- a/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
+++ b/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
@@ -60,13 +60,12 @@
         msg: "{{ data_set_name }}"
 
     ############################################################################
-    # Modules zos_data_set, zos_tso_command, zos_job_submit, zos_job_query,
+    # Modules zos_data_set, zos_job_submit, zos_job_query,
     # zos_job_output
     ############################################################################
     # +-------------------------------------------------------------------------
     # | Create a data set and member, create JCL on USS target, copy USS JCL to
-    # | data set, rename data set using TSO commands, submit JCL in data set,
-    # | query job, get job output.
+    # | data set, submit JCL in data set, query job, get job output.
     # +-------------------------------------------------------------------------
     - name: Create a PDS data set {{ data_set_name }}
       zos_data_set:
@@ -83,11 +82,10 @@
         msg: "{{ result }}"
 
     # +-------------------------------------------------------------------------
-    # | "with_sequence" is a type of Ansible loop. The loop here only runs for a
-    # | single iteration and is included solely to demonstrate how easy and
-    # | straightforward it would be to perform the operation for multiple
-    # | members. The end result of this block is a single member 'MEM1' is 
-    # | created.
+    # | "with_sequence" is a type of conditional Ansible loop. The loop here 
+    # | only runs for a single iteration and is included solely to demonstrate
+    # | how easy it is to perform the operation for multiple members. The result
+    # | is that single member 'MEM1' is created.
     # +-------------------------------------------------------------------------
     - name: Create a PDS member and replace if member exist
       zos_data_set:
@@ -105,6 +103,10 @@
       file:
         path: "{{ tgt_tmp_dir }}/ansible/jcl"
         state: directory
+
+    - name: Response for ensure JCL folder exists in USS to manage JCL
+      debug:
+        msg: "{{ result }}"
 
     - name: Write HELLO JCL to USS in {{ tgt_tmp_dir }}/ansible/jcl/HELLO"
         on target {{ inventory_hostname }}
@@ -133,39 +135,30 @@
       debug:
         msg: "{{ result }}"
 
-    - name: TSO commands to manage data set (LU, LISTDS, RENAME, LISTDS)
-      zos_tso_command:
-        commands:
-          - LU {{ ansible_user }}
-          - LISTDS '{{ data_set_name }}'
-          - RENAME '{{ data_set_name }}' '{{ data_set_name }}.LLQ'
-          - LISTDS '{{ data_set_name }}.LLQ'
-      register: result
-
-    - name: Response for TSO commands to manage data
-        set (LU, LISTDS, RENAME, LISTDS)
-      debug:
-        msg: "{{ result }}"
-
-    - name: Submit the JCL {{ data_set_name }}.LLQ(MEM1)
+    # +-------------------------------------------------------------------------
+    # | Similar to how we created the PDS member earlier, this is another
+    # | Ansible loop with a single iteration designed to showcase how multiple
+    # | jobs could be submitted under a single task for members of a single PDS
+    # +-------------------------------------------------------------------------
+    - name: Submit the JCL {{ data_set_name }}(MEM1)
       zos_job_submit:
-        src: "{{ data_set_name }}.LLQ(MEM{{ item }})"
+        src: "{{ data_set_name }}(MEM{{ item }})"
         location: DATA_SET
         wait: true
-      register: response
+      register: result
       with_sequence: count=1
 
-    - name: Response for submit the JCL {{ data_set_name }}.LLQ(MEM1)
+    - name: Response for submit the JCL {{ data_set_name }}.(MEM1)
       debug:
         msg: "{{ result }}"
 
-    - name: Query submitted job 'HELLO' in data set {{ data_set_name }}.LLQ
+    - name: Query submitted job 'HELLO' in data set {{ data_set_name }}
       zos_job_query:
         job_name: HELLO
       register: result
 
     - name: Response for query submitted job 'HELLO' in data
-        set {{ data_set_name }}.LLQ
+        set {{ data_set_name }}
       debug:
         msg: "{{ result }}"
 
@@ -178,15 +171,13 @@
       debug:
         msg: "{{ result }}"
 
-    # +-------------------------------------------------------------------------
-    # | Submit target JCL from USS, query for the submitted job and obtain the
-    # | job output, cleanup USS files and data sets.
-    # +-------------------------------------------------------------------------
+    - name: pause
+      pause:
 
-    - name: Response for write sample {{job_name}} JCL in {{ tgt_tmp_dir }}/ansible/jcl
-            on USS target
-      debug:
-        msg: "{{ result }}"
+    # +-------------------------------------------------------------------------
+    # | JCL from a USS file can also be submitted as a job by leveraging the 
+    # | zos_job_submit module.
+    # +-------------------------------------------------------------------------
 
     - name: Submit {{job_name}} jcl located on target
             in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
@@ -194,6 +185,8 @@
         src: "{{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
         location: USS
         wait: True
+      register: result
+        
 
     - name: Response for submit {{job_name}} jcl located on target
             in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
@@ -209,20 +202,32 @@
             on USS target
       debug:
         msg: "{{ result }}"
+    
+    # +-------------------------------------------------------------------------
+    # | The following section is commented out because it creates identical 
+    # | output to when the same job was submited earlier in the playbook 
+    # | from the PDS member. Feel free to uncomment the following section to
+    # | view the full job output.
+    # +-------------------------------------------------------------------------
 
-    - name: Get {{job_name}} job output on USS target
-      zos_job_output:
-        job_name: "{{job_name}}"
-      register: result
+    # - name: Get {{job_name}} job output on USS target
+    #   zos_job_output:
+    #     job_name: "{{job_name}}"
+    #   register: result
 
-    - name: Response for Get {{job_name}} job output on USS target
-      debug:
-        msg: "{{ result }}"
+    # - name: Response for Get {{job_name}} job output on USS target
+    #   debug:
+    #     msg: "{{ result }}"
+
+    # +-------------------------------------------------------------------------
+    # | Clean up - remove JCL files from USS, delete PDS.
+    # +-------------------------------------------------------------------------
 
     - name: Remove {{job_name}} JCL and folder on USS target
       file:
         path: "{{ tgt_tmp_dir }}/ansible"
         state: absent
+      register: result
 
     - name: Response for remove {{job_name}} JCL and folder on
             USS target
@@ -231,7 +236,7 @@
 
     - name: Delete data set {{ data_set_name }}
       zos_data_set:
-        name: "{{ data_set_name }}.LLQ"
+        name: "{{ data_set_name }}"
         state: absent
       register: result
 

--- a/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
+++ b/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
@@ -60,13 +60,16 @@
         msg: "{{ data_set_name }}"
 
     ############################################################################
-    # Modules zos_data_set, zos_job_submit, zos_job_query,
-    # zos_job_output
+    # Modules zos_data_set, zos_job_submit, zos_job_query, zos_job_output,
+    # zos_data_set, zos_copy.
     ############################################################################
     # +-------------------------------------------------------------------------
     # | Create a data set and member, create JCL on USS target, copy USS JCL to
-    # | data set, submit JCL in data set, query job, get job output.
+    # | data set, submit JCL in data set, query job, get job output. Repeat the
+    # | process with JCL submitted from USS file.
     # +-------------------------------------------------------------------------
+    ############################################################################
+
     - name: Create a PDS data set {{ data_set_name }}
       zos_data_set:
         name: "{{ data_set_name }}"
@@ -87,6 +90,7 @@
     # | how easy it is to perform the operation for multiple members. The result
     # | is that single member 'MEM1' is created.
     # +-------------------------------------------------------------------------
+
     - name: Create a PDS member and replace if member exist
       zos_data_set:
         name: "{{ data_set_name }}(MEM{{ item }})"
@@ -113,7 +117,6 @@
       zos_copy:
         src: "{{ playbook_dir }}/files/HELLO.jcl"
         dest: "{{ tgt_tmp_dir }}/ansible/jcl/HELLO"
-      # changed_when: true
       register: result
 
     - name: Response for write HELLO JCL to USS
@@ -136,10 +139,11 @@
         msg: "{{ result }}"
 
     # +-------------------------------------------------------------------------
-    # | Similar to how we created the PDS member earlier, this is another
+    # | Similar to how the PDS member was created earlier, this is another
     # | Ansible loop with a single iteration designed to showcase how multiple
     # | jobs could be submitted under a single task for members of a single PDS
     # +-------------------------------------------------------------------------
+
     - name: Submit the JCL {{ data_set_name }}(MEM1)
       zos_job_submit:
         src: "{{ data_set_name }}(MEM{{ item }})"
@@ -152,53 +156,73 @@
       debug:
         msg: "{{ result }}"
 
-    - name: Query submitted job 'HELLO' in data set {{ data_set_name }}
+    # +-------------------------------------------------------------------------
+    # | There is a list of results returned by the zos_job_submit module. Each 
+    # | result contains attributes from the job it refers to including job_id, 
+    # | job_name, owner, content, and return codes. Since only one job was
+    # | submitted, it will be the first (and only) job in the results list.  
+    # +-------------------------------------------------------------------------
+
+    - name: Setting fact `job_id_pds` for id of job submitted above
+      set_fact:
+        job_id_pds: "{{ result.results[0].job_id }}"
+    
+    - name: Fact `job_id_pds` set with value
+      debug:
+        msg: "{{ job_id_pds }}"
+
+    - name: Query submitted job by job_id
       zos_job_query:
-        job_name: HELLO
+        job_id: "{{ job_id_pds }}"
       register: result
 
-    - name: Response for query submitted job 'HELLO' in data
-        set {{ data_set_name }}
+    - name: Response for query submitted job by job_id
       debug:
         msg: "{{ result }}"
 
-    - name: Get HELLO job output
+    - name: Get job output for job {{ job_id_pds }} from PDS member
       zos_job_output:
-        job_name: HELLO
+        job_id: "{{ job_id_pds }}"
       register: result
 
-    - name: Response for get HELLO job output
+    - name: Response for get job output for job "{{ job_id_pds }}" from PDS
+        member
       debug:
         msg: "{{ result }}"
-
-    - name: pause
-      pause:
 
     # +-------------------------------------------------------------------------
     # | JCL from a USS file can also be submitted as a job by leveraging the 
     # | zos_job_submit module.
     # +-------------------------------------------------------------------------
 
-    - name: Submit {{job_name}} jcl located on target
-            in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
+    - name: Submit {{ job_name }} jcl located on target
+            in {{ tgt_tmp_dir }}/ansible/jcl/{{ job_name }}
       zos_job_submit:
-        src: "{{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
+        src: "{{ tgt_tmp_dir }}/ansible/jcl/{{ job_name }}"
         location: USS
         wait: True
       register: result
         
-
-    - name: Response for submit {{job_name}} jcl located on target
-            in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
+    - name: Response for submit {{ job_name }} jcl located on target
+            in {{ tgt_tmp_dir }}/ansible/jcl/{{ job_name }}
       debug:
-        msg: "{{ result }}"
+        msg:
+          - "{{ result }}"
 
-    - name: Query the submitted job {{job_name}} on USS target
+    - name: Setting fact `job_id_uss` for id of job submitted above
+      set_fact:
+        job_id_uss: "{{ result.job_id }}"
+    
+    - name: Fact `job_id_uss` set with value
+      debug:
+        msg: "{{ job_id_uss }}"
+
+    - name: Query the submitted job {{ job_name }} on USS target
       zos_job_query:
-        job_name: "{{job_name}}"
+        job_id: "{{ job_id_uss }}"
       register: result
 
-    - name: Response for Query the submitted job {{job_name}}
+    - name: Response for Query the submitted job {{ job_name }}
             on USS target
       debug:
         msg: "{{ result }}"
@@ -210,26 +234,28 @@
     # | view the full job output.
     # +-------------------------------------------------------------------------
 
-    # - name: Get {{job_name}} job output on USS target
+    # - name: Get job output for job {{ job_id_uss }} on USS target
     #   zos_job_output:
-    #     job_name: "{{job_name}}"
+    #     job_id: "{{ job_id_uss }}"
     #   register: result
 
-    # - name: Response for Get {{job_name}} job output on USS target
+    # - name: Response for Get {{ job_name }} job output on USS target
     #   debug:
     #     msg: "{{ result }}"
 
+    ############################################################################
     # +-------------------------------------------------------------------------
     # | Clean up - remove JCL files from USS, delete PDS.
     # +-------------------------------------------------------------------------
+    ############################################################################
 
-    - name: Remove {{job_name}} JCL and folder on USS target
+    - name: Remove {{ job_name }} JCL and folder on USS target
       file:
         path: "{{ tgt_tmp_dir }}/ansible"
         state: absent
       register: result
 
-    - name: Response for remove {{job_name}} JCL and folder on
+    - name: Response for remove {{ job_name }} JCL and folder on
             USS target
       debug:
         msg: "{{ result }}"

--- a/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
+++ b/zos_concepts/jobs/submit_query_retrieve/submit_query_retrieve.yml
@@ -253,29 +253,6 @@
       debug:
         msg: "{{ result }}"
 
-    - name: Create a PDS data set {{ data_set_name }}
-      zos_data_set:
-        name: "{{ data_set_name }}"
-        type: pds
-        size: 5M
-        format: fb
-        record_length: 25
-        replace: yes
-      register: result
-
-    - name: Response create a PDS data set {{ data_set_name }}
-      debug:
-        msg: "{{ result }}"
-
-    - name: Check if data set {{ data_set_name }} was created
-      command: "dls {{ data_set_name }}"
-      register: result
-      changed_when: true
-
-    - name: Response for check if data set {{ data_set_name }} was created
-      debug:
-        msg: "{{ result }}"
-
     - name: Delete data set {{ data_set_name }}
       zos_data_set:
         name: "{{ data_set_name }}"


### PR DESCRIPTION
generalizes the playbook more by removing direct references to the 'dimato' volume. 
removes and cleans up some of the initial fact settings - system_name is collected and set but never used. the pds data set name wasn't printed out but the sequential data set name was. 