### PR TITLE
[cloud_infra_center]fix fixed ip issue when add multiple workers

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
@@ -30,7 +30,6 @@
     set_fact: 
       add_worker_number: "{{ worker_number | default(1) }}"
       add_worker_ip: "{{ ip | default('random') }}"
-      update_bastion: "{{ update_bastion | default(false) }}"
 
   - name: 'Set worker ip'
     set_fact: 
@@ -56,17 +55,9 @@
       rm -rf .new_worker_name
       cut -d"," -f1 .new_worker_index >> .new_worker_name
 
-  - name: 'Add node ip into worker index'
-    shell: 
-      for i in $(seq 1 {{ add_worker_ip| length }}); do sed -i "s|$|$i|" .new_worker_index; done
-    when: add_worker_ip != "random"
-
   - name: 'Add worker ip'
     shell: |
-      for i in $(seq 1 {{ add_worker_ip| length }})
-      do
-          sed -i -e "0,/random$i/s//{{ item }}/" .new_worker_index
-      done
+        sed -i '0,/random/s//{{ item }}/' .new_worker_index
     with_items:
       - "{{ add_worker_ip}}"
     when: add_worker_ip != "random"
@@ -83,7 +74,7 @@
       - "{{ os_sg_worker }}"
       fixed_ips:
         - subnet: "{{ use_network_subnet }}"
-          ip_address: "{{ item.split(',')[1][:-2] | replace('ip=','') }}"
+          ip_address: "{{ item.split(',')[1] | replace('ip=','') }}"
     register: ports
     with_lines: cat .new_worker_index
     when: add_worker_ip != "random"
@@ -183,11 +174,6 @@
     - disk_type == "scsi"
     - volume_type_id is defined
 
-  - name: Remove last two characters in .new_worker_index
-    shell:
-      sed -i 's/.\{2\}$//' .new_worker_index
-    when: add_worker_ip != "random"
-
   - name: 'Update worker ip into new_worker_index file'
     shell: |
       worker_ip=$(openstack server list | grep "{{ item }}" | grep -oP "(?<=)\d+(\.\d+){3}")
@@ -203,4 +189,6 @@
     with_lines: cat .new_worker_name
 
 - import_playbook: modify-bastion.yaml
-  when: update_bastion == "true"
+  when: 
+  - update_bastion is defined
+  - update_bastion == "true"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/modify-bastion.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/modify-bastion.yaml
@@ -30,6 +30,25 @@
   hosts: bastion
   
   tasks:
+  - name: 'Validation worker ip address exist in named'
+    shell: |
+      rm -rf .validate_exist_ip
+      count=$(grep -Eo '{{ item.split(',')[1] | replace('ip=','') }}' /var/named/lynn.ocp.com.zone  | wc -l)
+      if [ $count != "0" ] ; then
+        echo 1 >> .validate_exist_ip
+      fi
+    with_lines: cat .new_worker_index
+
+  - name: check .validate_exist_ip exists
+    stat:
+      path: .validate_exist_ip
+    register: validate_ip_result
+
+  - name: Check if worker ip already exist in named
+    fail:
+      msg: "The assigned worker ip already exists in named file, please use another new ip address."
+    failed_when: validate_ip_result.stat.exists
+      
   - name: 'Modify bastion dns for new worker'
     include_tasks: modify-dns.yaml
     vars:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
@@ -47,11 +47,6 @@
     content: "{{ sunbet_range.stdout_lines[0]}}"
     dest: ".subnet_range.yml"
 
-- name: 'Save some basic info into yaml'
-  shell: |
-    rm -rf .new_ocp_node.yml
-    echo total_count={{ os_control_nodes_number | int }} >> .new_ocp_node.yml
-
 - name: 'Check netowrk name is properly set'
   fail:
     msg: "use_network_name is not defined!"


### PR DESCRIPTION
Fix five issues:
1.
``` 
ansible-playbook -i inventory.yaml add-new-compute-node.yaml -e worker_number=2 -e update_bastion=true -e ip=172.26.104.126,172.26.104.116
In create server port section, there will add index into IP , add 1 index but remove 2 index, which cause the final IP become 172.26.104.12,172.26.104.11
```

2.
```
ansible-playbook -i inventory.yaml add-new-compute-node.yaml -e worker_number=1 -e update_bastion=true -e ip=172.26.104.19
```

3.
```
ansible-playbook -i inventory.yaml add-new-compute-node.yaml -e worker_number=1 -e update_bastion=true -e ip=172.26.104.176
```
4. When user assign the IP which has been used, ICIC will give error. we need to give check when modify dns and haproxy , if the ip is here, give error to inform user to use the other IPs.

5. When user does not give the update_bastion=true, we will skip to update bastion info.

Already test those five issues on zvm 115 test stand.