### PR TITLE
[cloud_infra_center] update rhcos image and add gz_sha256 to verify image

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
@@ -97,7 +97,22 @@
   - name: 'Create the compute servers'
     os_server:
       name: "{{ item }}"
-      image: "rhcos"
+      image: "rhcos_qcow2"
+      flavor: "{{ os_flavor_worker }}"
+      auto_ip: no
+      timeout: "{{ create_server_timeout|int * 60 }}"
+      userdata: "{{ lookup('file', [ item , 'ignition.json'] | join('-'))  | string }}"
+      availability_zone: "{{ create_server_zone }}"
+      nics:
+        - port-name: "{{ item }}"
+    with_lines: cat .new_worker_name
+    when:
+    - vm_type == "kvm"
+    
+  - name: 'Create the compute servers'
+    os_server:
+      name: "{{ item }}"
+      image: "rhcos_{{ disk_type }}"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
       timeout: "{{ create_server_timeout|int * 60 }}"
@@ -108,6 +123,7 @@
     with_lines: cat .new_worker_name
     when:
     - disk_type == "dasd"
+    - vm_type == "zvm"
   
   - name: 'Convert compute server flavor from value into number'
     command:
@@ -119,7 +135,7 @@
   - name: 'Create the compute servers with default boot volume'
     os_server:
       name: "{{ item }}"
-      image: "rhcos"
+      image: "rhcos_{{ disk_type }}"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
       timeout: "{{ create_server_timeout|int * 60 }}"
@@ -133,13 +149,14 @@
     with_lines: cat .new_worker_name
     when:
     - disk_type == "scsi"
+    - vm_type == "zvm"
     - volume_type_id is not defined
 
   - name: 'Create compute boot volume'
     os_volume:
       state: present
       name: "{{ item }}-boot"
-      image: "rhcos"
+      image: "rhcos_{{ disk_type }}"
       size: "{{ compute_flavor_size.stdout_lines[0]}}"
       volume_type: "{{ volume_type_id }}"
       metadata: "{{ cluster_id_tag }}"
@@ -147,6 +164,7 @@
     with_lines: cat .new_worker_name
     when:
     - disk_type == "scsi"
+    - vm_type == "zvm"
     - volume_type_id is defined
   
   - name: 'Set compute volume bootable'
@@ -172,6 +190,7 @@
     with_lines: cat .new_worker_name
     when:
     - disk_type == "scsi"
+    - vm_type == "zvm"
     - volume_type_id is defined
 
   - name: 'Update worker ip into new_worker_index file'

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/add-new-compute-node.yaml
@@ -97,7 +97,7 @@
   - name: 'Create the compute servers'
     os_server:
       name: "{{ item }}"
-      image: "rhcos_qcow2"
+      image: "icic_rhcos_qcow2"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
       timeout: "{{ create_server_timeout|int * 60 }}"
@@ -112,7 +112,7 @@
   - name: 'Create the compute servers'
     os_server:
       name: "{{ item }}"
-      image: "rhcos_{{ disk_type }}"
+      image: "icic_rhcos_{{ disk_type }}"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
       timeout: "{{ create_server_timeout|int * 60 }}"
@@ -135,7 +135,7 @@
   - name: 'Create the compute servers with default boot volume'
     os_server:
       name: "{{ item }}"
-      image: "rhcos_{{ disk_type }}"
+      image: "icic_rhcos_{{ disk_type }}"
       flavor: "{{ os_flavor_worker }}"
       auto_ip: no
       timeout: "{{ create_server_timeout|int * 60 }}"
@@ -156,7 +156,7 @@
     os_volume:
       state: present
       name: "{{ item }}-boot"
-      image: "rhcos_{{ disk_type }}"
+      image: "icic_rhcos_{{ disk_type }}"
       size: "{{ compute_flavor_size.stdout_lines[0]}}"
       volume_type: "{{ volume_type_id }}"
       metadata: "{{ cluster_id_tag }}"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-images.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-images.yaml
@@ -26,10 +26,27 @@
   tasks:
 
   - name: Get existing rhcos image from ICIC glance
-    shell: "openstack image list --format value| grep -w 'rhcos'| wc -l"
+    shell: "openstack image list --format value| grep -w 'rhcos_qcow2'| wc -l"
     register: icic_rhcos_count
+    when:
+    - vm_type == "kvm"
 
   - name: 'Remove the rhcos image'
     shell:
-      cmd: "openstack image delete rhcos"
-    when: icic_rhcos_count.stdout | int == 1
+      cmd: "openstack image delete rhcos_qcow2"
+    when: 
+    - icic_rhcos_count.stdout | int == 1
+    - vm_type == "kvm"
+
+  - name: Get existing rhcos image from ICIC glance
+    shell: "openstack image list --format value| grep -w 'rhcos_{{ disk_type }}'| wc -l"
+    register: icic_rhcos_count
+    when:
+    - vm_type == "zvm"
+
+  - name: 'Remove the rhcos image'
+    shell:
+      cmd: "openstack image delete rhcos_{{ disk_type }}"
+    when: 
+    - icic_rhcos_count.stdout | int == 1
+    - vm_type == "zvm"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-images.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/destroy-images.yaml
@@ -26,27 +26,29 @@
   tasks:
 
   - name: Get existing rhcos image from ICIC glance
-    shell: "openstack image list --format value| grep -w 'rhcos_qcow2'| wc -l"
+    shell: "openstack image list --format value| grep -w 'icic_rhcos_qcow2'| wc -l"
     register: icic_rhcos_count
     when:
     - vm_type == "kvm"
 
   - name: 'Remove the rhcos image'
     shell:
-      cmd: "openstack image delete rhcos_qcow2"
+      cmd: "openstack image delete icic_rhcos_qcow2"
     when: 
-    - icic_rhcos_count.stdout | int == 1
     - vm_type == "kvm"
+    - icic_rhcos_count is defined
+    - icic_rhcos_count.stdout | int == 1
 
   - name: Get existing rhcos image from ICIC glance
-    shell: "openstack image list --format value| grep -w 'rhcos_{{ disk_type }}'| wc -l"
+    shell: "openstack image list --format value| grep -w 'icic_rhcos_{{ disk_type }}'| wc -l"
     register: icic_rhcos_count
     when:
     - vm_type == "zvm"
 
   - name: 'Remove the rhcos image'
     shell:
-      cmd: "openstack image delete rhcos_{{ disk_type }}"
+      cmd: "openstack image delete icic_rhcos_{{ disk_type }}"
     when: 
-    - icic_rhcos_count.stdout | int == 1
     - vm_type == "zvm"
+    - icic_rhcos_count is defined
+    - icic_rhcos_count.stdout | int == 1

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
@@ -41,7 +41,7 @@
 - name: 'Create the bootstrap server'
   os_server:
     name: "{{ os_bootstrap_server_name }}"
-    image: "rhcos_qcow2"
+    image: "icic_rhcos_qcow2"
     flavor: "{{ os_flavor_bootstrap }}"
     userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
     timeout: "{{ create_server_timeout|int * 60 }}" 
@@ -56,7 +56,7 @@
 - name: 'Create the bootstrap server'
   os_server:
     name: "{{ os_bootstrap_server_name }}"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_bootstrap }}"
     userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
     timeout: "{{ create_server_timeout|int * 60 }}" 
@@ -80,7 +80,7 @@
 - name: 'Create the bootstrap server with default boot volume'
   os_server:
     name: "{{ os_bootstrap_server_name }}"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_bootstrap }}"
     userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
     timeout: "{{ create_server_timeout|int * 60 }}" 
@@ -101,7 +101,7 @@
   os_volume:
     state: present
     name: "{{ os_bootstrap_server_name }}-boot"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     size: "{{ bootstrap_flavor_size.stdout_lines[0]}}"
     volume_type: "{{ volume_type_id }}"
     metadata: "{{ cluster_id_tag }}"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
@@ -41,7 +41,22 @@
 - name: 'Create the bootstrap server'
   os_server:
     name: "{{ os_bootstrap_server_name }}"
-    image: "rhcos"
+    image: "rhcos_qcow2"
+    flavor: "{{ os_flavor_bootstrap }}"
+    userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
+    timeout: "{{ create_server_timeout|int * 60 }}" 
+    auto_ip: no
+    availability_zone: "{{ create_server_zone }}"
+    nics:
+    - port-name: "{{ os_port_bootstrap }}"
+    meta: "{{ cluster_id_tag }}"
+  when:
+  - vm_type == "kvm"
+
+- name: 'Create the bootstrap server'
+  os_server:
+    name: "{{ os_bootstrap_server_name }}"
+    image: "rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_bootstrap }}"
     userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
     timeout: "{{ create_server_timeout|int * 60 }}" 
@@ -52,6 +67,7 @@
     meta: "{{ cluster_id_tag }}"
   when:
   - disk_type == "dasd"
+  - vm_type == "zvm"
 
 - name: 'Convert bootstrap flavor from value into number'
   command:
@@ -59,11 +75,12 @@
   register: bootstrap_flavor_size
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
 
 - name: 'Create the bootstrap server with default boot volume'
   os_server:
     name: "{{ os_bootstrap_server_name }}"
-    image: "rhcos"
+    image: "rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_bootstrap }}"
     userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
     timeout: "{{ create_server_timeout|int * 60 }}" 
@@ -77,25 +94,28 @@
     terminate_volume: True
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is not defined
 
 - name: 'Create bootstrap boot volume'
   os_volume:
     state: present
     name: "{{ os_bootstrap_server_name }}-boot"
-    image: "rhcos"
+    image: "rhcos_{{ disk_type }}"
     size: "{{ bootstrap_flavor_size.stdout_lines[0]}}"
     volume_type: "{{ volume_type_id }}"
     metadata: "{{ cluster_id_tag }}"
     timeout: "{{ create_server_timeout|int * 60 }} "
   when: 
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined
 
 - name: 'Set bootstrap volume bootable'
   shell: openstack --os-volume-api-version=3 volume set --bootable "{{ os_bootstrap_server_name }}-boot"
   when: 
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined
 
 - name: 'Create the bootstrap server with boot volume'
@@ -113,4 +133,5 @@
     terminate_volume: True
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
@@ -46,7 +46,7 @@
 - name: 'Create the compute servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos_qcow2"
+    image: "icic_rhcos_qcow2"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -62,7 +62,7 @@
 - name: 'Create the compute servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -86,7 +86,7 @@
 - name: 'Create the compute servers with default boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -108,7 +108,7 @@
   os_volume:
     state: present
     name: "{{ item.1 }}-{{ item.0 }}-boot"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     size: "{{ compute_flavor_size.stdout_lines[0]}}"
     volume_type: "{{ volume_type_id }}"
     metadata: "{{ cluster_id_tag }}"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
@@ -46,7 +46,23 @@
 - name: 'Create the compute servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos"
+    image: "rhcos_qcow2"
+    flavor: "{{ os_flavor_worker }}"
+    auto_ip: no
+    availability_zone: "{{ create_server_zone }}"
+    timeout: "{{ create_server_timeout|int * 60 }}" 
+    userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
+    nics:
+    - port-name: "{{ os_port_worker }}-{{ item.0 }}"
+    meta: "{{ cluster_id_tag }}"
+  with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
+  when:
+  - vm_type == "kvm"
+
+- name: 'Create the compute servers'
+  os_server:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    image: "rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -58,6 +74,7 @@
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:
   - disk_type == "dasd"
+  - vm_type == "zvm"
 
 - name: 'Convert compute node flavor from value into number'
   command:
@@ -69,7 +86,7 @@
 - name: 'Create the compute servers with default boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos"
+    image: "rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_worker }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -84,13 +101,14 @@
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is not defined
 
 - name: 'Create compute boot volume'
   os_volume:
     state: present
     name: "{{ item.1 }}-{{ item.0 }}-boot"
-    image: "rhcos"
+    image: "rhcos_{{ disk_type }}"
     size: "{{ compute_flavor_size.stdout_lines[0]}}"
     volume_type: "{{ volume_type_id }}"
     metadata: "{{ cluster_id_tag }}"
@@ -98,6 +116,7 @@
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined
 
 - name: 'Set compute volume bootable'
@@ -105,6 +124,7 @@
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when: 
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined
 
 - name: 'Create the compute server with boot volume'
@@ -123,4 +143,5 @@
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -69,7 +69,36 @@
 - name: 'Create the control servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos"
+    image: "rhcos_qcow2"
+    flavor: "{{ os_flavor_master }}"
+    auto_ip: no
+    availability_zone: "{{ create_server_zone }}"
+    timeout: "{{ create_server_timeout|int * 60 }}" 
+    # The ignition filename will be concatenated with the Control Plane node
+    # name and its 0-indexed serial number.
+    # In this case, the first node will look for this filename:
+    #    "{{ infraID }}-master-0-ignition.json"
+    userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
+    nics:
+    - port-name: "{{ os_port_master }}-{{ item.0 }}"
+    scheduler_hints:
+      group: "{{ server_group_id }}"
+    meta: "{{ cluster_id_tag }}"
+  with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
+  environment: 
+    PYTHONWARNINGS: 'ignore::UserWarning'
+  when:
+  - vm_type == "kvm"
+  register: create_master
+  failed_when:
+    - '"failed: [localhost]" in create_master'
+    - '"ValueError: dictionary update sequence element #0 has length 1; 2 is required" not in create_master'
+
+
+- name: 'Create the control servers'
+  os_server:
+    name: "{{ item.1 }}-{{ item.0 }}"
+    image: "rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -89,6 +118,7 @@
     PYTHONWARNINGS: 'ignore::UserWarning'
   when:
   - disk_type == "dasd"
+  - vm_type == "zvm"
   register: create_master
   failed_when:
     - '"failed: [localhost]" in create_master'
@@ -104,7 +134,7 @@
 - name: 'Create the control servers with default boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos"
+    image: "rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -127,6 +157,7 @@
     PYTHONWARNINGS: 'ignore::UserWarning'
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is not defined
   register: create_master
   failed_when:
@@ -137,7 +168,7 @@
   os_volume:
     state: present
     name: "{{ item.1 }}-{{ item.0 }}-boot"
-    image: "rhcos"
+    image: "rhcos_{{ disk_type }}"
     size: "{{ master_flavor_size.stdout_lines[0]}}"
     volume_type: "{{ volume_type_id }}"
     metadata: "{{ cluster_id_tag }}"
@@ -145,6 +176,7 @@
   with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
   when: 
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined
 
 - name: 'Set control volume bootable'
@@ -152,6 +184,7 @@
   with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
   when: 
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined
 
 - name: 'Create the control server with boot volume'
@@ -172,4 +205,5 @@
     PYTHONWARNINGS: 'ignore::UserWarning'
   when:
   - disk_type == "scsi"
+  - vm_type == "zvm"
   - volume_type_id is defined

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -69,7 +69,7 @@
 - name: 'Create the control servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos_qcow2"
+    image: "icic_rhcos_qcow2"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -98,7 +98,7 @@
 - name: 'Create the control servers'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -134,7 +134,7 @@
 - name: 'Create the control servers with default boot volume'
   os_server:
     name: "{{ item.1 }}-{{ item.0 }}"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     flavor: "{{ os_flavor_master }}"
     auto_ip: no
     availability_zone: "{{ create_server_zone }}"
@@ -168,7 +168,7 @@
   os_volume:
     state: present
     name: "{{ item.1 }}-{{ item.0 }}-boot"
-    image: "rhcos_{{ disk_type }}"
+    image: "icic_rhcos_{{ disk_type }}"
     size: "{{ master_flavor_size.stdout_lines[0]}}"
     volume_type: "{{ volume_type_id }}"
     metadata: "{{ cluster_id_tag }}"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
@@ -52,14 +52,14 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
@@ -83,7 +83,7 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=qcow2 --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2 rhcos
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=qcow2 --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2 rhcos_qcow2
   when: 
   - vm_type == "kvm"
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
@@ -52,14 +52,14 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos_{{ disk_type }}
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw icic_rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw rhcos_{{ disk_type }}
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=raw  --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw icic_rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
@@ -83,7 +83,7 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=qcow2 --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2 rhcos_qcow2
+    cmd: openstack image create --tag {{ cluster_id_tag }} --disk-format=qcow2 --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2 icic_rhcos_qcow2
   when: 
   - vm_type == "kvm"
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
@@ -30,16 +30,12 @@
 - name: Get existing RHCOS image from ICIC glance
   shell: |
     if [ {{ vm_type }} == "kvm" ]; then
-      a=$(openstack image list --format value| grep -w 'rhcos_qcow2'| awk '{print$1}')
+      a=$(openstack image list --format value| grep -w 'icic_rhcos_qcow2'| awk '{print$1}')
     else
-      a=$(openstack image list --format value| grep -w 'rhcos_{{ disk_type }}'| awk '{print$1}')
+      a=$(openstack image list --format value| grep -w 'icic_rhcos_{{ disk_type }}'| awk '{print$1}')
     fi
     if [ -z $a ]; then echo empty; else echo $a; fi
   register: icic_rhcos_id
-
-- name: debug 
-  debug:
-    msg: "{{icic_rhcos_id}}"
 
 - name: Get existing RHCOS image SHA256 from ICIC glance
   shell: |
@@ -83,9 +79,9 @@
 - name: Get new RHCOS image from ICIC glance
   shell: |
     if [ {{ vm_type }} == "kvm" ]; then
-      out=$(openstack image list | grep -w 'rhcos_qcow2' | wc -l)
+      out=$(openstack image list | grep -w 'icic_rhcos_qcow2' | wc -l)
     else
-      out=$(openstack image list | grep -w 'rhcos_{{ disk_type }}' | wc -l)
+      out=$(openstack image list | grep -w 'icic_rhcos_{{ disk_type }}' | wc -l)
     fi
     echo $out
   register: icic_rhcos_count
@@ -144,7 +140,7 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout}} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos_{{ disk_type }}
+    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout}} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x icic_rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
@@ -152,7 +148,7 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos_{{ disk_type }}
+    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x icic_rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
@@ -160,7 +156,7 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=qcow2 --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos_qcow2
+    cmd: openstack image create --disk-format=qcow2 --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x icic_rhcos_qcow2
   when: 
   - vm_type == "kvm"
   - icic_rhcos_count.stdout | int != 1

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
@@ -28,17 +28,28 @@
   register: openshift_rhcos_checksum_results
 
 - name: Get existing RHCOS image from ICIC glance
-  shell: "openstack image list --format value| grep -w 'rhcos'| awk '{print$1}'"
+  shell: |
+    if [ {{ vm_type }} == "kvm" ]; then
+      a=$(openstack image list --format value| grep -w 'rhcos_qcow2'| awk '{print$1}')
+    else
+      a=$(openstack image list --format value| grep -w 'rhcos_{{ disk_type }}'| awk '{print$1}')
+    fi
+    if [ -z $a ]; then echo empty; else echo $a; fi
   register: icic_rhcos_id
+
+- name: debug 
+  debug:
+    msg: "{{icic_rhcos_id}}"
 
 - name: Get existing RHCOS image SHA256 from ICIC glance
   shell: |
     if [ ! -z "{{ icic_rhcos_id.stdout }}" ]; then
-      echo $(openstack image show --format json -c properties {{ icic_rhcos_id.stdout }} | grep owner_specified.openstack.sha256 | cut -d ':' -f2 | sed 's/[^a-zA-Z0-9]//g')
+      echo $(openstack image show --format json -c properties {{ icic_rhcos_id.stdout }} | grep gz_sha256 | cut -d ':' -f2 | sed 's/[^a-zA-Z0-9]//g')
     else
       echo "rhcos"
     fi
   register: icic_rhcos_sha256_value
+  when: icic_rhcos_id.stdout != "empty"
 
 - name: Compare existing rhcos image with sha256
   shell: |
@@ -47,18 +58,37 @@
     elif [ ! -z "{{ icic_rhcos_id.stdout }}" ] && [ {{ vm_type }} = "zvm" ] && [ {{ disk_type }} = "dasd" ]; then
       count=$(grep -E '{{ icic_rhcos_sha256_value.stdout }}.*rhcos-dasd.s390x.raw.gz' .sha256sum_remote.txt | wc -l)
     elif [ ! -z "{{ icic_rhcos_id.stdout }}" ] && [ {{ vm_type }} = "kvm" ]; then
-      count=$(grep -E '{{ icic_rhcos_sha256_value.stdout }}.*rhcos-openstack.s390x.raw.gz' .sha256sum_remote.txt | wc -l)
+      count=$(grep -E '{{ icic_rhcos_sha256_value.stdout }}.*rhcos-openstack.*' .sha256sum_remote.txt | wc -l)
     else
       count=0
     fi
     echo $count
   register: use_local_rhcos
+  when: icic_rhcos_id.stdout != "empty"
 
-- name: Remove the existing RHCOS image from ICIC glance
-  shell: "openstack image delete rhcos"
+# - name: Remove the existing RHCOS image without sha256 from ICIC glance
+#   shell: "openstack image delete {{ item }}"
+#   with_items: "{{ icic_rhcos_id.stdout_lines }}"
+#   when: 
+#   - icic_rhcos_id.stdout != ""
+#   - icic_rhcos_sha256_value.stdout == ""
+
+- name: Remove the existing RHCOS image with unmatch sha256 from ICIC glance
+  shell: "openstack image delete {{ item }}"
+  with_items: "{{ icic_rhcos_id.stdout_lines }}"
   when: 
-  - icic_rhcos_id.stdout != ""
+  - icic_rhcos_id.stdout != "empty"
   - use_local_rhcos.stdout | int != 1
+
+- name: Get new RHCOS image from ICIC glance
+  shell: |
+    if [ {{ vm_type }} == "kvm" ]; then
+      out=$(openstack image list | grep -w 'rhcos_qcow2' | wc -l)
+    else
+      out=$(openstack image list | grep -w 'rhcos_{{ disk_type }}' | wc -l)
+    fi
+    echo $out
+  register: icic_rhcos_count
 
 - name: Download openshift rhcos metal image
   become: yes
@@ -70,7 +100,7 @@
   when:
   - vm_type == "zvm"
   - disk_type == "scsi"
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Download openshift rhcos dasd image
   become: yes
@@ -82,7 +112,7 @@
   when:
   - vm_type == "zvm"
   - disk_type == "dasd"
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Download openshift rhcos qcow2 image
   become: yes
@@ -93,50 +123,50 @@
     force: yes
   when:
   - vm_type == "kvm"
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Generate sha256 for local rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz
   shell: "sha256sum {{ openshift_install_dir }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz > .sha256sum_local.txt"
   when:
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Get sha256 for local rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz
   shell: "cat .sha256sum_local.txt | awk -F ' ' '{print $1}'"
   register: openshift_rhcos_sha256_results
   when:
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Unzip openshift rhcos image
   command:
     cmd: |
         gzip -d -f rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz
-  when: use_local_rhcos.stdout | int != 1
+  when: icic_rhcos_count.stdout | int != 1
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=raw  --property sha256={{ openshift_rhcos_sha256_results.stdout}} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos
+    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout}} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=raw  --property sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos
+    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=qcow2 --property sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos
+    cmd: openstack image create --disk-format=qcow2 --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x rhcos_qcow2
   when: 
   - vm_type == "kvm"
-  - use_local_rhcos.stdout | int != 1
+  - icic_rhcos_count.stdout | int != 1
 
 - name: Remove local RHCOS image
   file:
     state: absent
     path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x
-  when: use_local_rhcos.stdout | int != 1
+  when: icic_rhcos_count.stdout | int != 1


### PR DESCRIPTION
1) add metadata `gz_sha256` when uploading rhcos image
2) rename rhcos image name from `rhcos` to `icic_rhcos_<disk_type>`
3) fix adding compute node without update_bastion parameter

Tested on kvm, zvm dasd and zvm scsi environment, all passed.
```
zvm-dasd:
[root@bastion ocp_upi]# ./oc get nodes
NAME                     STATUS   ROLES    AGE    VERSION
lynn-r4d9q-master-0      Ready    master   110m   v1.24.0+b62823b
lynn-r4d9q-master-1      Ready    master   98m    v1.24.0+b62823b
lynn-r4d9q-master-2      Ready    master   98m    v1.24.0+b62823b
lynn-r4d9q-worker-3468   Ready    worker   10m    v1.24.0+b62823b
lynn-r4d9q-worker-5456   Ready    worker   11m    v1.24.0+b62823b
lynn-r4d9q-worker-7463   Ready    worker   26m    v1.24.0+b62823b

[root@bastion ocp_upi]# openstack image list
+--------------------------------------+-------------------------------+--------+
| ID                                   | Name                          | Status |
+--------------------------------------+-------------------------------+--------+
| d8cbb81f-b055-45a2-9c28-64571209be46 | RHEL86                        | active |
| 772a657a-d612-4292-af8a-70bfb511f844 | bootstrap-ignition-lynn-r4d9q | active |
| 54223a3b-03b5-46a8-b4e0-81ff35f5cfd7 | rhcos                         | active |
| db4522c7-158a-4e8a-99dd-b9790706e32a | icic_rhcos_dasd                    | active |
+--------------------------------------+-------------------------------+--------+
[root@bastion ocp_upi]#

kvm:
[root@bastion ocp_upi]# oc get nodes
NAME                  STATUS   ROLES    AGE     VERSION
lynn-z76n4-master-0   Ready    master   28m     v1.24.0+b62823b
lynn-z76n4-master-1   Ready    master   28m     v1.24.0+b62823b
lynn-z76n4-master-2   Ready    master   28m     v1.24.0+b62823b
lynn-z76n4-worker-0   Ready    worker   3m47s   v1.24.0+b62823b
lynn-z76n4-worker-1   Ready    worker   3m54s   v1.24.0+b62823b
[root@bastion ocp_upi]#

zvm-scsi:
[root@bastion ocp_upi_180]# openstack server list
+--------------------------------------+---------------------+--------+--------------------+--------------------------+--------+
| ID                                   | Name                | Status | Networks           | Image                    | Flavor |
+--------------------------------------+---------------------+--------+--------------------+--------------------------+--------+
| 99fb3032-56bb-42cd-b4d6-3b2b95abb8f5 | lynn-j4lrc-worker-2 | ACTIVE | net=172.26.108.114 | N/A (booted from volume) |        |
| 53e20cfc-182d-4937-9705-0895383927ac | lynn-j4lrc-worker-1 | ACTIVE | net=172.26.108.113 | N/A (booted from volume) |        |
| fa3d2a2e-499c-4b70-9116-b04a6ff37aed | lynn-j4lrc-worker-0 | ACTIVE | net=172.26.108.112 | N/A (booted from volume) |        |
| f98d2f49-cc53-4920-8b51-a28279bf4815 | lynn-j4lrc-master-2 | ACTIVE | net=172.26.108.118 | N/A (booted from volume) |        |
| 421ccf9f-a2e0-41ba-b723-a28ce69e9131 | lynn-j4lrc-master-1 | ACTIVE | net=172.26.108.119 | N/A (booted from volume) |        |
| 978ac8cf-515b-41ee-b7ea-ac33827b0f4e | lynn-j4lrc-master-0 | ACTIVE | net=172.26.108.116 | N/A (booted from volume) |        |
+--------------------------------------+---------------------+--------+--------------------+--------------------------+--------+
[root@bastion ocp_upi_180]# export KUBECONFIG=auth/kubeconfig
[root@bastion ocp_upi_180]# oc get nodes
NAME                  STATUS   ROLES    AGE    VERSION
lynn-j4lrc-master-0   Ready    master   145m   v1.24.0+b62823b
lynn-j4lrc-master-1   Ready    master   141m   v1.24.0+b62823b
lynn-j4lrc-master-2   Ready    master   134m   v1.24.0+b62823b
lynn-j4lrc-worker-0   Ready    worker   16m    v1.24.0+b62823b
lynn-j4lrc-worker-1   Ready    worker   15m    v1.24.0+b62823b
lynn-j4lrc-worker-2   Ready    worker   12m    v1.24.0+b62823b
```