### PR TITLE
[cloud_infra_center] add latest tag for minor version

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -246,8 +246,8 @@ Update your settings based on the samples. The following propeties are **require
 | `use_network_subnet` | \<subnet id from network name in icic\> |`openstack network list -c Subnets -f value`|
 | `vm_type` | kvm| The operation system of OpenShift Container Platform, <br>supported: `kvm` or `zvm`| |
 | `disk_type` | dasd|The disk storage of OpenShift Container Platform, <br>supported: `dasd` or `scsi` | |
-| `openshift_version` |4.10| The product version of OpenShift Container Platform, <br>such as `4.6` or `4.7` or `4.8`. <br> And the rhcos is not updated for every single minor version. User can get available openshift_version from [here](https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/)| |
-| `openshift_minor_version` |3| The minor version of Openshift Container Platform, <br>such as `3`.  <br>For openshift_version `4.10` for example, the only rhcos release available is `4.10.3`, and user can inspect what minor releases are available by checking [here](https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/4.10/) to see whats there | 
+| `openshift_version` |4.10| The product version of OpenShift Container Platform, <br>such as `4.8` or `4.9` or `4.10` or `4.11`. <br> And the rhcos is not updated for every single minor version. User can get available openshift_version from [here](https://mirror.openshift.com/pub/openshift-v4/s390x/dependencies/rhcos/)| |
+| `openshift_minor_version` |3| The minor version of Openshift Container Platform, <br>such as `3`.Support to use `latest` tag to install the latest minor version under`openshift_version` <br> And User can inspect what minor releases are available by checking [here](https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/) to see whats there | 
 | `auto_allocated_ip` |true|(Boolean) true or false, if false, <br>IPs will be allocated from `allocation_pool_start` and `allocation_pool_end` |
 | `os_flavor_bootstrap` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB  | |
 | `os_flavor_master` | medium| `openstack flavor list`, Minimum flavor disk size >= 35 GiB | |

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -41,8 +41,8 @@ all:
       disk_type: 'dasd' # dasd or scsi
       #volume_type_id: '<storage-template-id>'
       
-      openshift_version: '4.7'
-      openshift_minor_version: '7'
+      openshift_version: '4.11'
+      openshift_minor_version: 'latest' #9
       
       auto_allocated_ip: true  # true or false
       #allocation_pool_start: '<ip range start>'

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-client/tasks/main.yaml
@@ -1,7 +1,7 @@
 # =================================================================
 # Licensed Materials - Property of IBM
 #
-# (c) Copyright IBM Corp. 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2022 All Rights Reserved
 #
 # US Government Users Restricted Rights - Use, duplication or
 # disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
@@ -10,9 +10,19 @@
 ---
 # tasks file for configure-installer-and-image
 
+- name: Verify openshift minor version
+  shell: |
+    version=$(curl -s https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}/release.txt | grep 'Name:' | awk -F: '{print $2}' | xargs)
+    if [ -z $version ]; then
+      echo $(curl -s https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/latest-{{ openshift_version }}/release.txt | grep 'Name:' | awk -F: '{print $2}' | xargs)
+    else
+      echo $version
+    fi
+  register: icic_ocp_version
+
 - name: 'Set fact for openshift client'
   set_fact:
-    openshift_client_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ openshift_version }}.{{ openshift_minor_version }}"
+    openshift_client_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/clients/ocp/{{ icic_ocp_version.stdout }}"
     openshift_install_dir: "."
 
 - name: Get checksum for local openshift-install-linux.tar.gz

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/tasks/main.yaml
@@ -1,7 +1,7 @@
 # =================================================================
 # Licensed Materials - Property of IBM
 #
-# (c) Copyright IBM Corp. 2021 All Rights Reserved
+# (c) Copyright IBM Corp. 2022 All Rights Reserved
 #
 # US Government Users Restricted Rights - Use, duplication or
 # disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
@@ -11,9 +11,19 @@
 - name: 'Import common yaml'
   import_tasks: common.yaml
 
-- name: 'Set fact for openshift client'
+- name: Verify openshift minor version
+  shell: |
+    version=$(curl -s https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}/sha256sum.txt | grep rhcos | wc -l)
+    if [ $version -eq "0" ] || [ "{{ openshift_minor_version }}" -eq "latest" ]; then
+      echo $(curl -s https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/latest/sha256sum.txt | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" | head -n1)
+    else
+      echo "{{ openshift_version }}.{{ openshift_minor_version }}"
+    fi
+  register: icic_ocp_version
+
+- name: 'Set fact for openshift rhcos url'
   set_fact:
-    openshift_rhcos_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ openshift_version }}.{{ openshift_minor_version }}"
+    openshift_rhcos_url: "https://mirror.openshift.com/pub/openshift-v4/{{ ansible_architecture }}/dependencies/rhcos/{{ openshift_version }}/{{ icic_ocp_version.stdout }}"
     openshift_install_dir: "."
 
 - name: Download checksum for the rhcos image
@@ -88,8 +98,8 @@
 
 - name: Download openshift rhcos metal image
   get_url:
-    url: "{{ openshift_rhcos_url }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-metal.s390x.raw.gz"
-    dest: "{{ openshift_install_dir }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz"
+    url: "{{ openshift_rhcos_url }}/rhcos-{{ icic_ocp_version.stdout }}-s390x-metal.s390x.raw.gz"
+    dest: "{{ openshift_install_dir }}/rhcos-{{ icic_ocp_version.stdout }}-s390x.gz"
   when:
   - vm_type == "zvm"
   - disk_type == "scsi"
@@ -97,8 +107,8 @@
 
 - name: Download openshift rhcos dasd image
   get_url:
-    url: "{{ openshift_rhcos_url }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-dasd.s390x.raw.gz"
-    dest: "{{ openshift_install_dir }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz"
+    url: "{{ openshift_rhcos_url }}/rhcos-{{ icic_ocp_version.stdout }}-s390x-dasd.s390x.raw.gz"
+    dest: "{{ openshift_install_dir }}/rhcos-{{ icic_ocp_version.stdout }}-s390x.gz"
   when:
   - vm_type == "zvm"
   - disk_type == "dasd"
@@ -106,18 +116,18 @@
 
 - name: Download openshift rhcos qcow2 image
   get_url:
-    url: "{{ openshift_rhcos_url }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x-openstack.s390x.qcow2.gz"
-    dest: "{{ openshift_install_dir }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz"
+    url: "{{ openshift_rhcos_url }}/rhcos-{{ icic_ocp_version.stdout }}-s390x-openstack.s390x.qcow2.gz"
+    dest: "{{ openshift_install_dir }}/rhcos-{{ icic_ocp_version.stdout }}-s390x.gz"
   when:
   - vm_type == "kvm"
   - icic_rhcos_count.stdout | int != 1
 
-- name: Generate sha256 for local rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz
-  shell: "sha256sum {{ openshift_install_dir }}/rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz > .sha256sum_local.txt"
+- name: Generate sha256 for local rhcos-{{ icic_ocp_version.stdout }}-s390x.gz
+  shell: "sha256sum {{ openshift_install_dir }}/rhcos-{{ icic_ocp_version.stdout }}-s390x.gz > .sha256sum_local.txt"
   when:
   - icic_rhcos_count.stdout | int != 1
 
-- name: Get sha256 for local rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz
+- name: Get sha256 for local rhcos-{{ icic_ocp_version.stdout}}-s390x.gz
   shell: "cat .sha256sum_local.txt | awk -F ' ' '{print $1}'"
   register: openshift_rhcos_sha256_results
   when:
@@ -126,12 +136,12 @@
 - name: Unzip openshift rhcos image
   command:
     cmd: |
-        gzip -d -f rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.gz
+        gzip -d -f rhcos-{{ icic_ocp_version.stdout }}-s390x.gz
   when: icic_rhcos_count.stdout | int != 1
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout}} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x icic_rhcos_{{ disk_type }}
+    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout}} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=SCSI --file=rhcos-{{ icic_ocp_version.stdout }}-s390x icic_rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "scsi"
@@ -139,7 +149,7 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x icic_rhcos_{{ disk_type }}
+    cmd: openstack image create --disk-format=raw  --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=ZVM --property disk_type=DASD --file=rhcos-{{ icic_ocp_version.stdout }}-s390x icic_rhcos_{{ disk_type }}
   when: 
   - vm_type == "zvm"
   - disk_type == "dasd"
@@ -147,7 +157,7 @@
 
 - name: Upload RHCOS image to ICIC glance
   command: 
-    cmd: openstack image create --disk-format=qcow2 --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x icic_rhcos_qcow2
+    cmd: openstack image create --disk-format=qcow2 --property gz_sha256={{ openshift_rhcos_sha256_results.stdout }} --property architecture=s390x --property os_name=Linux --property os_version=RHCOS{{ openshift_version }} --property os_distro=RHCOS{{ openshift_version }} --property hypervisor_type=kvm --file=rhcos-{{ icic_ocp_version.stdout }}-s390x icic_rhcos_qcow2
   when: 
   - vm_type == "kvm"
   - icic_rhcos_count.stdout | int != 1
@@ -155,5 +165,5 @@
 - name: Remove local RHCOS image
   file:
     state: absent
-    path: rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x
+    path: rhcos-{{ icic_ocp_version.stdout }}-s390x
   when: icic_rhcos_count.stdout | int != 1


### PR DESCRIPTION
1. add latest tag for openshift_minor_version
2. compare the specified minor_version, if not exist, query the latest version under `openshift_version`
3. update README doc