### PR TITLE
[cloud_infra_center] Update restart haproxy service

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-haproxy/tasks/main.yml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-haproxy/tasks/main.yml
@@ -150,14 +150,20 @@
   become_method: sudo
   shell: setsebool -P haproxy_connect_any=1
 
-- name: start haproxy
+# - name: start haproxy
+#   become: yes
+#   become_user: root
+#   become_method: sudo
+#   service:
+#     name: haproxy
+#     state: started
+#     enabled: yes
+
+- name: Restart haproxy
   become: yes
   become_user: root
   become_method: sudo
-  service:
-    name: haproxy
-    state: started
-    enabled: yes
+  service: name=haproxy state=restarted
 
 - name: Restart firewalld
   become: yes


### PR DESCRIPTION
Fix to restart haproxy service.

Test scenario:
1. deploy OCP on kvm,  destory it and redeploy again.
2. deploy OCP on zvm-dasd,  destory it and redeploy again.

Verify the haproxy server should be restarted after running `bastion.yaml`, if not restart successfully, the master can not resolve the `api-int` domain.