### PR TITLE
[cloud_infra_center] add custom_dns for kvm platform

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap/tasks/main.yaml
@@ -64,7 +64,7 @@
     availability_zone: "{{ create_server_zone }}"
     nics:
     - port-name: "{{ os_port_bootstrap }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
   when:
   - disk_type == "dasd"
   - vm_type == "zvm"
@@ -88,7 +88,7 @@
     availability_zone: "{{ create_server_zone }}"
     nics:
     - port-name: "{{ os_port_bootstrap }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     boot_from_volume: True
     volume_size: "{{ bootstrap_flavor_size.stdout_lines[0]}}"
     terminate_volume: True

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes/tasks/main.yaml
@@ -70,7 +70,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:
   - disk_type == "dasd"
@@ -94,7 +94,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     boot_from_volume: True
     volume_size: "{{ compute_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
@@ -138,7 +138,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     terminate_volume: True
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane/tasks/main.yaml
@@ -112,7 +112,7 @@
     - port-name: "{{ os_port_master }}-{{ item.0 }}"
     scheduler_hints:
       group: "{{ server_group_id }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
   with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
   environment: 
     PYTHONWARNINGS: 'ignore::UserWarning'
@@ -148,7 +148,7 @@
     - port-name: "{{ os_port_master }}-{{ item.0 }}"
     scheduler_hints:
       group: "{{ server_group_id }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     boot_from_volume: True
     volume_size: "{{ master_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
@@ -198,7 +198,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_master }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     terminate_volume: True
   with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
   environment: 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-config/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-config/tasks/main.yaml
@@ -18,7 +18,7 @@
 - name: 'Get the subnet range'
   command:
     cmd: "openstack subnet show {{ use_network_subnet }} -c cidr -f value"
-  register: sunbet_range
+  register: subnet_range
 
 - name: Create install-config.yaml
   template:
@@ -26,7 +26,7 @@
     dest: "install-config.yaml"
 
 - name: Configure machine network in install configuration
-  script: tools/config-machine-network.py {{ sunbet_range.stdout_lines[0] }}
+  script: tools/config-machine-network.py {{ subnet_range.stdout_lines[0] }}
   args:
     executable: python3
 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
@@ -70,6 +70,8 @@
 - name: "Remove all DNS nameserver of subnet {{ use_network_subnet }}"
   command:
     cmd: "openstack subnet set --no-dns-nameservers {{ use_network_subnet }} "
+  when:
+  - vm_type == "kvm"
 
 - name: 'Update new DNS nameserver and allocation pool of subnet {{ use_network_subnet }}'
   command:
@@ -77,6 +79,7 @@
   when:
   - allocation_pool_start is defined
   - allocation_pool_end is defined 
+  - vm_type == "kvm"
 
 - name: 'Update new DNS nameserver of subnet {{ use_network_subnet }}'
   command:
@@ -84,12 +87,31 @@
   when:
   - allocation_pool_start is not defined
   - allocation_pool_end is not defined 
+  - vm_type == "kvm"
 
 - name: 'Update new DNS nameserver and partial allocation pool of subnet {{ use_network_subnet }}'
   command:
     cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} --allocation-pool start={{ allocation_pool_start | default(sunbet_range.stdout_lines[0] | next_nth_usable(10)) }},end={{ allocation_pool_end | default(os_subnet_range | ipaddr('last_usable')) }} {{ use_network_subnet }}"
-  when: (allocation_pool_start is not defined and allocation_pool_end is defined) or
-        (allocation_pool_start is defined and allocation_pool_end is not defined)
+  when: 
+  - (allocation_pool_start is not defined and allocation_pool_end is defined) or
+    (allocation_pool_start is defined and allocation_pool_end is not defined)
+  - vm_type == "kvm"
+
+- name: 'Update allocation pool of subnet {{ use_network_subnet }}'
+  command:
+    cmd: "openstack subnet set --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} {{ use_network_subnet }}"
+  when:
+  - allocation_pool_start is defined
+  - allocation_pool_end is defined 
+  - vm_type == "zvm"
+
+- name: 'Update partial allocation pool of subnet {{ use_network_subnet }}'
+  command:
+    cmd: "openstack subnet set --allocation-pool start={{ allocation_pool_start | default(sunbet_range.stdout_lines[0] | next_nth_usable(10)) }},end={{ allocation_pool_end | default(os_subnet_range | ipaddr('last_usable')) }} {{ use_network_subnet }}"
+  when: 
+  - (allocation_pool_start is not defined and allocation_pool_end is defined) or
+    (allocation_pool_start is defined and allocation_pool_end is not defined)
+  - vm_type == "zvm"
 
 - name: 'Export infra ID'
   shell:


### PR DESCRIPTION
1) Add `custom_dns` when creating servers on z/VM.
2) Remove the update nameserver on z/VM, only KVM needs to update ICIC network with DNS info.
3) Update the wrong word of `subnet`

Test scenario:
1. Deploy OCP on KVM with default DNS nameserver
2. Deploy OCP on KVM with empty DNS nameserver
3. Deploy OCP on z/VM with default DNS nameserver
4. Deploy OCP on z/VM with empty DNS nameserver

I have covered those two test scenarios. The case1, case2 and case3 are deploying OCP successful with minimal configuration(3 masters). But case4 is failed because the default network does not have any DNS to resolve, so bootkube.service is not succeeded.
