### PR TITLE
[cloud_infra_center] add custom_dns for zvm platform

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap-zvm/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-bootstrap-zvm/tasks/main.yaml
@@ -55,7 +55,7 @@
     availability_zone: "{{ create_server_zone }}"
     nics:
     - port-name: "{{ os_port_bootstrap }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
   when:
   - disk_type == "dasd"
   - vm_type == "zvm"
@@ -79,7 +79,7 @@
     availability_zone: "{{ create_server_zone }}"
     nics:
     - port-name: "{{ os_port_bootstrap }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     boot_from_volume: True
     volume_size: "{{ bootstrap_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
@@ -118,7 +118,7 @@
     availability_zone: "{{ create_server_zone }}"
     nics:
     - port-name: "{{ os_port_bootstrap }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     terminate_volume: True
   when:
   - disk_type == "scsi"

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes-zvm/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-compute-nodes-zvm/tasks/main.yaml
@@ -61,7 +61,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:
   - disk_type == "dasd"
@@ -85,7 +85,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     boot_from_volume: True
     volume_size: "{{ compute_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
@@ -127,7 +127,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_worker }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     terminate_volume: True
   with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
   when:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane-zvm/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-control-plane-zvm/tasks/main.yaml
@@ -89,7 +89,7 @@
     - port-name: "{{ os_port_master }}-{{ item.0 }}"
     scheduler_hints:
       group: "{{ server_group_id }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
   with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
   environment: 
     PYTHONWARNINGS: 'ignore::UserWarning'
@@ -125,7 +125,7 @@
     - port-name: "{{ os_port_master }}-{{ item.0 }}"
     scheduler_hints:
       group: "{{ server_group_id }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     boot_from_volume: True
     volume_size: "{{ master_flavor_size.stdout_lines[0]}}"
     terminate_volume: True
@@ -173,7 +173,7 @@
     userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
     nics:
     - port-name: "{{ os_port_master }}-{{ item.0 }}"
-    meta: "{{ cluster_id_tag }}"
+    meta: "{{ cluster_id_tag }},custom_dns={{ os_dns_domain }}"
     terminate_volume: True
   with_indexed_items: "{{ [os_cp_server_name] * os_control_nodes_number }}"
   environment: 

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
@@ -70,6 +70,8 @@
 - name: "Remove all DNS nameserver of subnet {{ use_network_subnet }}"
   command:
     cmd: "openstack subnet set --no-dns-nameservers {{ use_network_subnet }} "
+  when:
+  - vm_type == "kvm"
 
 - name: 'Update new DNS nameserver and allocation pool of subnet {{ use_network_subnet }}'
   command:
@@ -77,6 +79,7 @@
   when:
   - allocation_pool_start is defined
   - allocation_pool_end is defined 
+  - vm_type == "kvm"
 
 - name: 'Update new DNS nameserver of subnet {{ use_network_subnet }}'
   command:
@@ -84,12 +87,31 @@
   when:
   - allocation_pool_start is not defined
   - allocation_pool_end is not defined 
+  - vm_type == "kvm"
 
 - name: 'Update new DNS nameserver and partial allocation pool of subnet {{ use_network_subnet }}'
   command:
     cmd: "openstack subnet set --dns-nameserver {{ os_dns_domain }} --allocation-pool start={{ allocation_pool_start | default(sunbet_range.stdout_lines[0] | next_nth_usable(10)) }},end={{ allocation_pool_end | default(os_subnet_range | ipaddr('last_usable')) }} {{ use_network_subnet }}"
-  when: (allocation_pool_start is not defined and allocation_pool_end is defined) or
-        (allocation_pool_start is defined and allocation_pool_end is not defined)
+  when:
+  - (allocation_pool_start is not defined and allocation_pool_end is defined) or
+    (allocation_pool_start is defined and allocation_pool_end is not defined)
+  - vm_type == "kvm"
+
+- name: 'Update allocation pool of subnet {{ use_network_subnet }}'
+  command:
+    cmd: "openstack subnet set --allocation-pool start={{ allocation_pool_start }},end={{ allocation_pool_end }} {{ use_network_subnet }}"
+  when:
+  - allocation_pool_start is defined
+  - allocation_pool_end is defined 
+  - vm_type == "zvm"
+
+- name: 'Update partial allocation pool of subnet {{ use_network_subnet }}'
+  command:
+    cmd: "openstack subnet set --allocation-pool start={{ allocation_pool_start | default(sunbet_range.stdout_lines[0] | next_nth_usable(10)) }},end={{ allocation_pool_end | default(os_subnet_range | ipaddr('last_usable')) }} {{ use_network_subnet }}"
+  when: 
+  - (allocation_pool_start is not defined and allocation_pool_end is defined) or
+    (allocation_pool_start is defined and allocation_pool_end is not defined)
+  - vm_type == "zvm"
 
 - name: 'Export infra ID'
   shell:


### PR DESCRIPTION
Retest with latest code on zvm test stand.

```
TASK [Show bootstrapping log] *******************************************************************************************************
ok: [localhost] => {
    "bootstrap_log.stdout_lines": [
        "time=\"2023-01-05T03:58:36-05:00\" level=info msg=\"Waiting up to 30m0s (until 4:28AM) for bootstrapping to complete...\"",
        "time=\"2023-01-05T04:09:53-05:00\" level=debug msg=\"Bootstrap status: complete\"",
        "time=\"2023-01-05T04:09:53-05:00\" level=info msg=\"It is now safe to remove the bootstrap resources\"",
        "time=\"2023-01-05T04:09:53-05:00\" level=debug msg=\"Time elapsed per stage:\"",
        "time=\"2023-01-05T04:09:53-05:00\" level=debug msg=\"Bootstrap Complete: 11m18s\"",
        "time=\"2023-01-05T04:09:53-05:00\" level=info msg=\"Time elapsed: 11m18s\""
    ]
}

PLAY [localhost] ********************************************************************************************************************

TASK [Export infra ID] **************************************************************************************************************
changed: [localhost]

TASK [Compute resource names] *******************************************************************************************************
ok: [localhost]

TASK [Remove the bootstrap server] **************************************************************************************************
changed: [localhost]

PLAY RECAP **************************************************************************************************************************
localhost                  : ok=20   changed=10   unreachable=0    failed=0    skipped=33   rescued=0    ignored=0

[root@kvm4ocp2 ocp_upi_zvm]#
[root@kvm4ocp2 ocp_upi_zvm]#
[root@kvm4ocp2 ocp_upi_zvm]# export KUBECONFIG=auth/kubeconfig
[root@kvm4ocp2 ocp_upi_zvm]# oc get nodes
NAME                  STATUS   ROLES    AGE     VERSION
lynn-6rglk-master-0   Ready    master   18m     v1.24.6+5658434
lynn-6rglk-master-1   Ready    master   13m     v1.24.6+5658434
lynn-6rglk-master-2   Ready    master   4m48s   v1.24.6+5658434
[root@kvm4ocp2 ocp_upi_zvm]#
```
