### PR TITLE
feat: added sample for module_defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ often repeated and in need of automation.
     - [Deploy a program to a CICS region](zos_subsystems/cics/cmci/deploy_program)
     - [Customize when a CMCI module should fail](zos_subsystems/cics/cmci/override_failure)
     - [Resource life cycle and CSD](zos_subsystems/cics/cmci/resource_lifecycle_and_csd)
+    - [Using module_defaults](zos_subsystems/cics/cmci/module_defaults)
   - [MQ](zos_subsystems/mq)
     - [Interacting with local queues](zos_subsystems/mq/mqsc/qlocal)
 	- [Backing up an application structure](zos_subsystems/mq/mqsc/cfstruct)

--- a/zos_subsystems/cics/cmci/module_defaults/README.md
+++ b/zos_subsystems/cics/cmci/module_defaults/README.md
@@ -1,0 +1,93 @@
+# Using module_defaults to install a program definition
+
+This sample playbook demonstrates how to use the `cmci_get` module from the
+`ibm_zos_cics` collection to retrieve operational data from running CICS
+regions.
+
+This example retrieves information corresponding to the `CICSRGN`
+resource table, but can be adapted to retrieve information about any of the
+resource tables supported by CICSPlex SM. The retrieved information is written
+to a CSV file, which you can open as a spreadsheet.
+
+This sample additionally shows how to automate installation of pre-requisites
+for the `cmci_*` modules.
+
+## Requirements
+
+- Python 3.84+
+- Ansible-core 2.12+
+
+## Getting Started
+
+You will need to have set up the CMCI REST API in your CICS environment. You
+can enable the CMCI REST API in either CICSPlex SM environments, or in
+stand-alone CICS regions. The `cmci_*` modules use the *CMCI REST API* to
+interact with your CICS environment.
+
+For detailed installation instructions please consult
+[the documentation](https://ibm.github.io/z_ansible_collections_doc/installation/installation.html).
+
+You can install the IBM z/OS CICS collection from Ansible Galaxy by using the
+`ansible-galaxy` CLI, which is supplied with your Ansible installation:
+
+```bash
+ansible-galaxy collection install ibm.ibm_zos_cics
+```
+
+For more information about the CMCI REST API, see the
+[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/5.6?topic=environment-cics-management-client-interface-cmci).
+
+Because this playbook only uses the CMCI REST API, it can be run on the control node directly, without having to
+configure an inventory. Generally you'll be able to use this trick with any of the CMCI modules. In this example, we
+run the `cmci_get` module on `localhost`, i.e. the Ansible control node, by setting the target host to localhost.
+Running the CMCI modules on the control node can be a good idea, because you don't have to deal with the complexity of
+an unnecessary SSH connection, and you don't have to install the modules' dependencies on the remote host.
+
+The `cmci_*` modules have pre-requisites that need to be installed into the Python environment in which the module
+executes. In this case, the `cmci_get` module will be executed on `localhost`, i.e. the Ansible control
+node. The playbook demonstrates how you can ensure the pre-requisites are installed (wherever the module runs) before
+the `cmci_get` module is executed. More information about the `cmci_*` module pre-requisites can be found in the
+[documentation](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_cics/docs/source/requirements_managed.html).
+
+## Run [program_lifecycle.yml](program_lifecycle.yml)
+
+You can run the playbook without modification:
+
+```bash
+ansible-playbook program_lifecycle.yml
+````
+
+The playbook will prompt for required parameters. After parameters have been supplied, the playbook installs the
+CMCI module dependencies to the python environment. The playbook then creates and checks CICS resources before deleting them. Specifically, it creates and updates a program definition, installs it and checks the program is installed,and finally disables the program and deletes it along with the program definition.
+
+The module_defaults section at the top of the playbook allows some parameters to be passed to a group, in this case the group `group/ibm.ibm_zos_cics.cmci_group` so any tasks that are part of that group inherit those parameters. This means the rest of the playbooks `cmci_group` tasks can omit CMCI connection information as they will get that info from the module_defaults.
+
+## What next?
+
+- To avoid being prompted for parameters, you can try supplying the input parameters on the command line directly:
+
+  ```bash
+  ansible-playbook -e "context=MYCTXT cmci_host=example.com" report.yml
+  ```
+  
+  Parameters specified in this way won't be prompted for. Have a look at the `vars_prompt` section of the playbook to
+  work out the names of the variables to use on the CLI.
+
+  You can also edit the playbook to switch the `vars_prompt` for a `vars` section, to stop Ansible prompting for the
+  values when executing the playbook. You will still be able to override any default values you set with the `-e`
+  command line argument. For information about how to set variables, see
+  [the Ansible documentation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html).
+
+- Look at the [other samples](../..) to find examples of what else you can do with the CICS collection.
+
+# Support
+
+Please refer to the [support section](../../../../README.md/#support) for more details.
+
+# License
+
+Licensed under [Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0).
+
+# Copyright
+
+© Copyright IBM Corporation 2023.

--- a/zos_subsystems/cics/cmci/module_defaults/program_lifecycle.yml
+++ b/zos_subsystems/cics/cmci/module_defaults/program_lifecycle.yml
@@ -1,0 +1,216 @@
+# (c) Copyright IBM Corporation 2023
+# Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
+###############################################################################
+# Contributed by the Ansible Content for IBM Z Team
+#
+# Changelog
+#  All notable changes to this sample will be documented in this playbook
+#
+# 2023-04-21
+#  - Released initial version
+###############################################################################
+# This sample playbook demonstrates potential module_default usage
+# for CMCI connection information
+#
+# Usage:
+#  ansible-playbook program_lifecycle.yml
+#
+# Notes:
+#  This sample playbook demonstrates how using module_defaults can allow
+#  a user to omit details in tasks and use a group to provide applicable
+#  tasks with parameters. The module_defaults block at the top sets some
+#  CMCI connection paramters, and then in the CMCI tasks themselves, these
+#  connection details do not need to be written out again.
+#
+# Requirements:
+#   IBM z/OS CICS collection 1.0.4 or later
+###############################################################################
+---
+- name: CICS CMCI module_defaults
+
+  hosts: "localhost"
+  gather_facts: false
+
+  vars_prompt:
+    - name: cmci_host
+      prompt: Target CMCI hostname
+      private: false
+    - name: cmci_port
+      prompt: Target CMCI port
+      private: false
+    - name: scheme
+      prompt: CMCI scheme (leave blank for http)
+      private: false
+      default: http
+    - name: context
+      prompt: Target CPSM context (CICSPlex)
+      private: false
+    - name: cmci_scope
+      prompt: Target CPSM scope (Region)
+      private: false
+    - name: cmci_user
+      prompt: CMCI user name (leave blank for unauthenticated)
+      private: false
+    - name: cmci_password
+      prompt: CMCI password (leave blank for unauthenticated)
+    - name: csdgroup
+      prompt: CSD Group to create resources within
+      private: false
+    - name: program
+      prompt: Program name to create (and then delete)
+      private: false
+
+  module_defaults:
+    group/ibm.ibm_zos_cics.cmci_group:
+      cmci_host: "{{ cmci_host }}"
+      cmci_port: "{{ cmci_port }}"
+      cmci_user: "{{ cmci_user }}"
+      cmci_password: "{{ cmci_password }}"
+      context: "{{ context }}"
+      scope: "{{ cmci_scope }}"
+      scheme: "{{ scheme }}"
+      insecure: true
+
+  tasks:
+    ############################################################################
+    # Install module dependencies
+    ############################################################################
+    - name: Make sure CMCI module dependencies are installed
+      ansible.builtin.pip:
+        name:
+          - requests
+          - xmltodict
+          - typing;python_version<"3.5"
+
+    ############################################################################
+    # Get information about CICS regions from the supplied context, using CMCI
+    ############################################################################
+    - name: Get information about CICS regions
+      ibm.ibm_zos_cics.cmci_get:
+        context: "{{ context }}"
+        cmci_host: "{{ cmci_host }}"
+        cmci_port: "{{ cmci_port | int }}"
+        cmci_user: "{{ cmci_user | default(omit) }}"
+        cmci_password: "{{ cmci_password | default(omit) }}"
+        scheme: "{{ scheme }}"
+        type: "CICSRegion"
+      register: result
+
+    ############################################################################
+    # Create a program definition
+    ############################################################################
+    - name: HTTP Create progdef
+      ibm.ibm_zos_cics.cmci_create:
+        type: CICSDefinitionProgram
+        attributes:
+          name: "{{ program }}"
+          csdgroup: "{{ csdgroup }}"
+        create_parameters:
+          - name: CSD
+      register: result
+      failed_when: false
+
+    ############################################################################
+    # Update a program definition
+    ############################################################################
+    - name: HTTP Update progdef
+      delegate_to: localhost
+      ibm.ibm_zos_cics.cmci_update:
+        type: CICSDefinitionProgram
+        attributes:
+          description: foo
+        resources:
+          filter:
+            NAME: "{{ program }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    ############################################################################
+    # Install a program definition
+    ############################################################################
+    - name: HTTP Install program
+      delegate_to: localhost
+      ibm.ibm_zos_cics.cmci_action:
+        type: CICSDefinitionProgram
+        action_name: CSDINSTALL
+        resources:
+          filter:
+            NAME: "{{ program }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result
+      failed_when: false
+
+    ############################################################################
+    # Check a program was installed
+    ############################################################################
+    - name: HTTP Check program was installed
+      delegate_to: localhost
+      ibm.ibm_zos_cics.cmci_get:
+        type: CICSProgram
+        resources:
+          filter:
+            PROGRAM: "{{ program }}"
+      retries: 3 # May take a while to install, so give it a chance!
+      until: result is not failed
+      register: result
+      failed_when: false
+
+    ############################################################################
+    # Disable a program
+    ############################################################################
+    - name: HTTP Disable program
+      delegate_to: localhost
+      ibm.ibm_zos_cics.cmci_update:
+        type: CICSProgram
+        attributes:
+          status: disabled
+        resources:
+          filter:
+            PROGRAM: "{{ program }}"
+          complex_filter:
+            and:
+              - attribute: PROGRAM
+                operator: "="
+                value: "{{ program }}"
+              - or:
+                  - attribute: USECOUNT
+                    operator: "!="
+                    value: "0"
+                  - attribute: USECOUNT
+                    operator: LT
+                    value: "1"
+      register: result
+      failed_when: false
+
+    ############################################################################
+    # Delete a program
+    ############################################################################
+    - name: HTTP Delete program
+      delegate_to: localhost
+      ibm.ibm_zos_cics.cmci_delete:
+        type: CICSProgram
+        resources:
+          filter:
+            PROGRAM: "{{ program }}"
+      register: result
+      failed_when: false
+
+    ############################################################################
+    # Delete a program definition
+    ############################################################################
+    - name: HTTP Delete program defintion
+      delegate_to: localhost
+      ibm.ibm_zos_cics.cmci_delete:
+        type: CICSDefinitionProgram
+        resources:
+          filter:
+            NAME: "{{ program }}"
+          get_parameters:
+            - name: CSDGROUP
+              value: "{{ csdgroup }}"
+      register: result


### PR DESCRIPTION
Adds a new folder for CICS subsystems with a module_defaults sample playbook and adds a link to the main pages README