### PR TITLE
Add http/https SG rules to master SG when three nodes install

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-manifests/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-manifests/tasks/main.yaml
@@ -22,3 +22,4 @@
   ansible.builtin.script: tools/make-control-plane-unschedulable.py
   args:
     executable: python3
+  when: os_compute_nodes_number > 0

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-security-groups/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-security-groups/tasks/main.yaml
@@ -189,6 +189,21 @@
     protocol: '112'
     remote_ip_prefix: "{{ sunbet_range.stdout_lines[0] }}"
 
+- name: 'Create master-sg rule "Ingress HTTP"'
+  openstack.cloud.security_group_rule:
+    security_group: "{{ os_sg_master }}"
+    protocol: tcp
+    port_range_min: 80
+    port_range_max: 80
+  when: os_compute_nodes_number == 0
+
+- name: 'Create master-sg rule "Ingress HTTPS"'
+  openstack.cloud.security_group_rule:
+    security_group: "{{ os_sg_master }}"
+    protocol: tcp
+    port_range_min: 443
+    port_range_max: 443
+  when: os_compute_nodes_number == 0
 
 - name: 'Create worker-sg rule "ICMP"'
   openstack.cloud.security_group_rule:


### PR DESCRIPTION
When install OCP with only 3 master nodes, ingress operator will be run on master nodes, which require TCP 80/443 SG rules.