### PR TITLE
Roles path fixes

### DIFF
--- a/zos_concepts/volume_management/volume_initialization/init_dasd_vol_and_run_sample_jcl/ansible.cfg
+++ b/zos_concepts/volume_management/volume_initialization/init_dasd_vol_and_run_sample_jcl/ansible.cfg
@@ -11,7 +11,7 @@
 
 [defaults]
 forks = 25
-roles_path = ../../../roles:.
+roles_path = ../../../../roles:.
 
 [ssh_connection]
 pipelining = True

--- a/zos_concepts/zfsadm/zfs_grow_aggr/ansible.cfg
+++ b/zos_concepts/zfsadm/zfs_grow_aggr/ansible.cfg
@@ -11,6 +11,7 @@
 
 [defaults]
 forks = 25
+roles_path = ../../../roles:..
 
 [ssh_connection]
 pipelining = True

--- a/zos_concepts/zos_ping/ansible.cfg
+++ b/zos_concepts/zos_ping/ansible.cfg
@@ -17,5 +17,5 @@ pipelining = True
 
 # For Ansible versions 2.11 or later
 [connection]
-pipelining = true
+pipelining = False
 

--- a/zos_concepts/zos_ping/ansible.cfg
+++ b/zos_concepts/zos_ping/ansible.cfg
@@ -9,7 +9,7 @@
 ################################################################################
 [defaults]
 forks = 25
-roles_path = ../../../roles:.
+roles_path = ../../roles:.
 
 # For Ansible versions less than 2.11
 [ssh_connection]
@@ -17,5 +17,5 @@ pipelining = True
 
 # For Ansible versions 2.11 or later
 [connection]
-pipelining = False
+pipelining = true
 


### PR DESCRIPTION
Select samples that leverage the role `requirements-check` did not have the `role_path` variable set appropriately in their respective `ansible.cfg` files, thus some users experienced a role not found error. 