### PR TITLE
Create node with sepcific name.

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/common.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/common.yaml
@@ -35,14 +35,43 @@
     # Security groups names
     os_sg_master: "{{ infra_id.stdout_lines[0] }}-master"
     os_sg_worker: "{{ infra_id.stdout_lines[0] }}-worker"
-    # Server names
-    os_bootstrap_server_name: "{{ infra_id.stdout_lines[0] }}-bootstrap"
-    os_cp_server_name: "{{ infra_id.stdout_lines[0] }}-master"
-    os_cp_server_group_name: "{{ infra_id.stdout_lines[0] }}-master"
-    os_compute_server_name: "{{ infra_id.stdout_lines[0] }}-worker"
     # Ignition files
     os_bootstrap_ignition: "{{ infra_id.stdout_lines[0] }}-bootstrap-ignition.json"
-    # BFV volume names
-    os_bootstrap_bfv_name: "{{ infra_id.stdout_lines[0] }}-bootstrap-boot"
-    os_master_bfv_name: "{{ infra_id.stdout_lines[0] }}-master-boot"
-    os_worker_bfv_name: "{{ infra_id.stdout_lines[0] }}-worker-boot"
+
+- name: 'Bootstrap server names with prefix'
+  ansible.builtin.set_fact:
+    os_bootstrap_server_name: "{{ bootstrap_name_prefix }}"
+  when:
+    - bootstrap_name_prefix is defined
+
+- name: 'Bootstrap server names without prefix'
+  ansible.builtin.set_fact:
+    os_bootstrap_server_name: "{{ infra_id.stdout_lines[0] }}-bootstrap"
+  when:
+    - bootstrap_name_prefix is not defined
+
+- name: 'Master server names with prefix'
+  ansible.builtin.set_fact:
+    os_cp_server_name: "{{ master_name_prefix }}"
+    os_cp_server_group_name: "{{ master_name_prefix }}"
+  when:
+    - master_name_prefix is defined
+
+- name: 'Master server names without prefix'
+  ansible.builtin.set_fact:
+    os_cp_server_name: "{{ infra_id.stdout_lines[0] }}-master"
+    os_cp_server_group_name: "{{ infra_id.stdout_lines[0] }}-master"
+  when:
+    - master_name_prefix is not defined
+
+- name: 'Worker server names without prefix'
+  ansible.builtin.set_fact:
+    os_compute_server_name: "{{ infra_id.stdout_lines[0] }}-worker"
+  when:
+    - worker_name_prefix is not defined
+
+- name: 'Worker server names without prefix'
+  ansible.builtin.set_fact:
+    os_compute_server_name: "{{ worker_name_prefix }}"
+  when:
+    - worker_name_prefix is defined

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/inventory.yaml
@@ -87,5 +87,8 @@ all:
     os_dns_domain: '<external-dns-ip-addr>'
     cluster_name: '<cluster-name>'
     base_domain: '<cluster-base-domain>'
+    bootstrap_name_prefix: ''
+    master_name_prefix: ''
+    worker_name_prefix: ''
     pullsecret: '<pull-secret>'
     sshkey: '<ssh-key>'

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
@@ -40,12 +40,12 @@
   register: glance_token
 
 - name: Generate bootstrap ignition shim
-  ansible.builtin.script: tools/generate-bootstrap-ignitionshim.py {{ image_url.stdout_lines[0] }} {{ glance_token.stdout }} {{ infra_id.stdout_lines[0] }}
+  ansible.builtin.script: tools/generate-bootstrap-ignitionshim.py {{ image_url.stdout_lines[0] }} {{ glance_token.stdout }} {{ infra_id.stdout_lines[0] }} {{ bootstrap_name_prefix }}
   args:
     executable: python3
 
 - name: Generate master ignition
-  ansible.builtin.script: tools/generate-master-ignition.sh {{ infra_id.stdout_lines[0] }} {{ os_control_nodes_number }}
+  ansible.builtin.script: tools/generate-master-ignition.sh {{ infra_id.stdout_lines[0] }} {{ os_control_nodes_number }} {{ master_name_prefix }}
 
 - name: Generate worker ignition
-  ansible.builtin.script: tools/generate-worker-ignition.sh {{ infra_id.stdout_lines[0] }} {{ os_compute_nodes_number }}
+  ansible.builtin.script: tools/generate-worker-ignition.sh {{ infra_id.stdout_lines[0] }} {{ os_compute_nodes_number }} {{ worker_name_prefix }}

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-bootstrap-ignitionshim.py
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-bootstrap-ignitionshim.py
@@ -54,6 +54,22 @@ if ca_cert_path:
       }
     })
 
+name_prefix = sys.argv[4]
+if name_prefix:
+    name_prefix_byte = name_prefix.encode()
+    bootstrap_hostname = base64.standard_b64encode(name_prefix_byte).decode().strip()
+    files.update(
+    {
+      "storage": {
+        "files": {
+          "path": "/etc/hostname", 
+          "mode": 420, 
+          "contents": {
+              "source": "data:text/plain;charset=utf-8;base64," + bootstrap_hostname
+          }
+        }    
+      }
+    })
 infra_id = sys.argv[3]
 if infra_id:
     with open(infra_id+'-bootstrap-ignition.json', 'a') as f:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-master-ignition.sh
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-master-ignition.sh
@@ -10,9 +10,16 @@
 
 infra_id=$1
 master_end=$(($2 - 1))
+name_prefix=$3
 
 for index in $( seq 0 $master_end); do
-    MASTER_HOSTNAME="$infra_id-master-$index\n"
+    if [ -n "$name_prefix" ]; then
+        MASTER_HOSTNAME="$name_prefix-$index\n"
+        IGNITION_NAME="$name_prefix-$index"
+    else
+        MASTER_HOSTNAME="$infra_id-master-$index\n"
+        IGNITION_NAME="$infra_id-master-$index"
+    fi
     python -c "import base64, json, sys
 ignition = json.load(sys.stdin)
 storage = ignition.get('storage', {})
@@ -20,5 +27,5 @@ files = storage.get('files', [])
 files.append({'path': '/etc/hostname', 'mode': 420, 'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + base64.standard_b64encode(b'$MASTER_HOSTNAME').decode().strip()},'filesystem': 'root'})
 storage['files'] = files
 ignition['storage'] = storage
-json.dump(ignition, sys.stdout)" < master.ign > "$infra_id-master-$index-ignition.json"
+json.dump(ignition, sys.stdout)" < master.ign > "$IGNITION_NAME-ignition.json"
 done

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-worker-ignition.sh
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/generate-worker-ignition.sh
@@ -9,9 +9,16 @@
 # =================================================================
 infra_id=$1
 worker_end=$(($2 - 1))
+name_prefix=$3
 
 for index in $( seq 0 $worker_end); do
-    WORKER_HOSTNAME="$infra_id-worker-$index\n"
+    if [ -n "$name_prefix" ]; then
+        WORKER_HOSTNAME="$name_prefix-$index\n"
+        IGNITION_NAME="$name_prefix-$index"
+    else
+        WORKER_HOSTNAME="$infra_id-worker-$index\n"
+        IGNITION_NAME="$infra_id-worker-$index"
+    fi
     python -c "import base64, json, sys
 ignition = json.load(sys.stdin)
 storage = ignition.get('storage', {})
@@ -19,5 +26,5 @@ files = storage.get('files', [])
 files.append({'path': '/etc/hostname', 'mode': 420, 'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + base64.standard_b64encode(b'$WORKER_HOSTNAME').decode().strip()},'filesystem': 'root'})
 storage['files'] = files
 ignition['storage'] = storage
-json.dump(ignition, sys.stdout)" < worker.ign > "$infra_id-worker-$index-ignition.json"
+json.dump(ignition, sys.stdout)" < worker.ign > "$IGNITION_NAME-ignition.json"
 done


### PR DESCRIPTION
In [documentation](https://github.com/IBM/z_ansible_collections_samples/blob/main/z_infra_provisioning/cloud_infra_center/ocp_upi/docs/add-dns-haproxy.md) we list example for DNS entries but are using the playbook generated hostnames. In customer environment they have a common OCP naming convention across x and p. They would like to add z to the environment but prefer to keep same naming convention as listed above:
```
ocp4zkboot (bootstrap)
ocp4zkm01 (master-1)
ocp4zkm02 (master-2)
ocp4zkm03 (master-3)
ocp4zkw01 (worker-1)
ocp4zkw02 (worker-2)
ocp4zkw03 (worker-3)
```