### PR TITLE
add disconnected installation for ocp

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/Disconnected_Installation.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/Disconnected_Installation.md
@@ -1,0 +1,140 @@
+This guide provides step-by-step instructions for setting up a disconnected installation of the OpenShift Container Platform (OCP) on IBM Cloud Infrastructure Center. Follow these instructions to prepare your environment, set up the necessary infrastructure, and configure OCP for a successful installation.
+
+### 1. Prepare Two Machines
+
+- **(Ansible Host)** : This machine is optional but can be used for running Ansible Playbook.
+
+- **(Bastion Host)** : This machine is required and must have internal network connectivity to communicate with your OCP nodes.
+
+Check [Preparation of the servers](./README.md#1-preparation-of-the-servers) for how to prepare them.
+
+### 2. Pre-requisite Packages
+
+First, download the required packages from an online server, and copy those packages to the Ansible Host, then install packages on Ansible Host.
+
+Check [Installation of packages on a Linux server](./README.md#2-installation-of-packages-on-a-linux-server).
+
+### 3. Set Up Mirror Registry
+
+To set up a mirror registry, use for mirroring the required container images of OpenShift Container Platform for disconnected installations. Following [guide](https://docs.openshift.com/container-platform/4.12/installing/disconnected_install/installing-mirroring-installation-images.html) to setup mirror registry.
+
+And we offer temporary script to setup registry and mirror images, you can get scripts from [mirror-registry](tools/mirror-registry/)
+
+Update the following variables in the scripts as needed:
+- **01-mirror-registry.sh**:
+
+    - PULL_SECRET: (required)The secret to download openshift images
+    - VERSION: (required)The openshift version, such as: `4.8.14`
+    - CLIENT_ARCH: (required)The architecture of running script machine, such as: `x86_64` or `s390x`
+    - IMAGE_ARCH: (required)The architecture for openshift, such as: `s390x`
+- **00-setup-registry.sh**:
+    - LOCAL_REGISTRY_USERNAME: Credentials for your registry, such as: `icic`
+    - LOCAL_REGISTRY_PASSWORD: Credentials for your registry, such as: `icic`
+    - LOCAL_REGISTRY_HOSTNAME: Repository name for storing the mirrored images, such as: `image.registry.icic.ocp.com`
+    - LOCAL_REGISTRY_PORT: Repository port for storing the mirrored images, such as: `5008`
+
+**Note**: Copy the mirror registry `/opt/registry/certs/domain.crt` into Ansible Host:/opt/registry/certs/
+
+### 4. Add Mirror Registry Domain
+
+After running `bastion.yaml`, we will remove the existing domain record in the named configuration. Please remember to add it again after running `bastion.yaml` to avoid any missing data. Follow these steps to re-add the domain `image.registry.icic.ocp.com`:
+
+1. Edit the named.conf:
+Add the zone information for `image.registry.icic.ocp.com` in named.conf file on Bastion Host.
+```
+vi /etc/named.conf
+
+zone "image.registry.icic.ocp.com" {
+        type master;
+        file "image.registry.icic.ocp.com.zone";
+        allow-query { any; };
+        allow-transfer { none; };
+        allow-update { none; };
+}
+```
+
+2. Create the Zone File:
+Create the zone file /var/named/image.registry.icic.ocp.com.zone with the DNS records.
+```
+$TTL 1D
+@       IN SOA  @ rname.invalid. (
+                                        0       ; serial
+                                        1D      ; refresh
+                                        1H      ; retry
+                                        1W      ; expire
+                                        3H )    ; minimum
+        NS      @
+        A       <Mirror_Registry_Server_IP_Address>
+```
+
+3. Restart named-chroot:
+Restart the DNS service to apply the changes.
+```
+systemctl restart named-chroot
+```
+
+4. Verify the DNS Configuration:
+Use nslookup to ensure the domain is correctly configured and resolvable.
+```
+nslookup image.registry.icic.ocp.com
+```
+
+5. Test Mirror Registry Access:
+Verify that the mirror registry is accessible from the bastion host using curl.
+```
+curl -u icic:icic --insecure https://image.registry.icic.ocp.com:5008/v2/_catalog
+```
+
+### 5. Prepare Openshift Client and RHCOS images
+
+Update the inventory.yaml file with the URLs or file paths for the OpenShift client and RHCOS images. 
+Example entry:
+```
+      use_localreg: true # true or false
+      localreg_mirror: "image.registry.icic.ocp.com:5008/icic/openshift4"
+
+      local_openshift_install: '/ocp_upi/openshift-install-linux.tar.gz'
+      local_openshift_client: '/ocp_upi/openshift-client-linux.tar.gz'
+      local_rhcos_image: '/ocp_upi/rhcos-4.8.14-s390x-openstack.s390x.qcow2.gz'
+
+      additional_certs: "{{ lookup('file', '/opt/registry/certs/domain.crt') | indent (width=2) }}"
+```
+
+### 6. Openshift Deployment
+Then follow the other steps of Openshift deployment, finally you will get a cluster with your mirror registry:
+
+```
+[root@XXX ocp_upi]# ./oc get imagecontentsourcepolicy -o yaml
+apiVersion: v1
+items:
+- apiVersion: operator.openshift.io/v1alpha1
+  kind: ImageContentSourcePolicy
+  metadata:
+    creationTimestamp: "2024-07-11T11:02:21Z"
+    generation: 1
+    name: image-policy-0
+    resourceVersion: "931"
+    uid: a005cc44-edeb-4bda-a6f2-1f57a69667e9
+  spec:
+    repositoryDigestMirrors:
+    - mirrors:
+      - image.registry.icic.ocp.com:5008/icic/openshift4
+      source: quay.io/openshift-release-dev/ocp-release
+- apiVersion: operator.openshift.io/v1alpha1
+  kind: ImageContentSourcePolicy
+  metadata:
+    creationTimestamp: "2024-07-11T11:02:22Z"
+    generation: 1
+    name: image-policy-1
+    resourceVersion: "964"
+    uid: e1eb4641-8ffa-4bcb-9454-634141613dfb
+  spec:
+    repositoryDigestMirrors:
+    - mirrors:
+      - image.registry.icic.ocp.com:5008/icic/openshift4
+      source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+```

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/README.md
@@ -348,6 +348,8 @@ Others are **optional**, you can enable them and update value if you need more s
 | `create_server_timeout`   | 10                                                      | Default is 10 minutes that used to create instances and volumes from backend storage provider                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 
 
+**Note**: Check [Disconnected installation](./Disconnected_Installation.md) for setting up a disconnected installation of the OpenShift Container Platform (OCP).
+
 **Note**: Check [OpenShift on a single node](./SNO.md) for how to define single node cluster.
 
 ## Creation of the cluster

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-haproxy/tasks/main.yml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-haproxy/tasks/main.yml
@@ -191,12 +191,6 @@
     name: firewalld
     state: started
 
-- name: Restart the mirror registry
-  ansible.builtin.shell: |
-    systemctl daemon-reload
-    systemctl restart ocp-registry
-  when: "{{ hostvars['localhost']['use_localreg'] }} == true"
-
 # - name: Report status of haproxy
 #   fail:
 #     msg: |

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
@@ -13,27 +13,85 @@
 - name: 'Import common yaml'
   ansible.builtin.include_tasks: "{{ playbook_dir }}/common.yaml"
 
-- name: Download RHCOS image
-  ansible.builtin.shell: |
-    if [  -f {{ local_rhcos_image }} ]; then
-        gzip -d -c {{ local_rhcos_image }} > rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw
-    else
-        curl -Lf {{ local_rhcos_image }} > rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
-        gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+- name: Check if {{ local_rhcos_image }} is a URL
+  set_fact:
+    is_url: "{{ local_rhcos_image.startswith('https://') }}"
+
+- name: Download and uncompress the RHCOS image if {{ local_rhcos_image }} is a URL
+  shell: |
+    if [ -f "rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw" ]; then
+      rm -f "rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw"
     fi
+    curl -Lf {{ local_rhcos_image }} > rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+    gunzip -f rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw.gz
+  register: download_uncompress_result
+  ignore_errors: true
   when:
     - vm_type == "zvm"
+    - is_url
 
-- name: Download RHCOS image
-  ansible.builtin.shell: |
-    if [  -f {{ local_rhcos_image }} ]; then
-        gzip -d -c {{ local_rhcos_image }} > rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2
-    else
-        curl -Lf {{ local_rhcos_image }} > rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
-        gzip -d rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
+- name: Fail if download or uncompress fails if {{ local_rhcos_image }} is a URL
+  fail:
+    msg: "Failed to download or uncompress the file from the URL: {{ local_rhcos_image }}"
+  when: 
+    - is_url 
+    - vm_type == "zvm"
+    - download_uncompress_result.rc != 0
+
+- name: Download and uncompress the RHCOS image if {{ local_rhcos_image }} is a file path
+  shell: |
+     gunzip -c "{{ local_rhcos_image }}" > "rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.raw"
+  register: copy_uncompress_result
+  ignore_errors: true
+  when:
+    - vm_type == "zvm"
+    - not is_url
+
+- name: Fail if copy or uncompress fails if {{ local_rhcos_image }} is a file path
+  fail:
+    msg: "Failed to copy or uncompress the file from the path: {{ local_rhcos_image }}. Error: {{ copy_uncompress_result.stderr }}"
+  when: 
+    - not is_url 
+    - vm_type == "zvm"
+    - copy_uncompress_result.rc != 0
+    
+- name: Download and uncompress the RHCOS image if {{ local_rhcos_image }} is a URL
+  shell: |
+    if [ -f "rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2" ]; then
+      rm -f "rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2"
     fi
+    curl -Lf {{ local_rhcos_image }} > rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
+    gunzip -f rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2.gz
+  register: download_uncompress_result
+  ignore_errors: true
   when:
     - vm_type == "kvm"
+    - is_url
+
+- name: Fail if download or uncompress fails if {{ local_rhcos_image }} is a URL
+  fail:
+    msg: "Failed to download or uncompress the file from the URL: {{ local_rhcos_image }}"
+  when: 
+    - is_url 
+    - vm_type == "kvm"
+    - download_uncompress_result.rc != 0
+
+- name: Download and uncompress the RHCOS image if {{ local_rhcos_image }} is a file path
+  shell: |
+     gunzip -c "{{ local_rhcos_image }}" > "rhcos-{{ openshift_version }}.{{ openshift_minor_version }}-s390x.qcow2"
+  register: copy_uncompress_result
+  ignore_errors: true
+  when:
+    - vm_type == "kvm"
+    - not is_url
+
+- name: Fail if copy or uncompress fails if {{ local_rhcos_image }} is a file path
+  fail:
+    msg: "Failed to copy or uncompress the file from the path: {{ local_rhcos_image }}. Error: {{ copy_uncompress_result.stderr }}"
+  when: 
+    - not is_url
+    - vm_type == "kvm"
+    - copy_uncompress_result.rc != 0
 
 - name: Upload RHCOS image to ICIC glance
   ansible.builtin.command:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/mirror-registry/01-mirror-registry.sh
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/mirror-registry/01-mirror-registry.sh
@@ -8,10 +8,11 @@ LOCAL_REGISTRY_USERNAME="icic"
 LOCAL_REGISTRY_PASSWORD="icic"
 LOCAL_REGISTRY_HOSTNAME="image.registry.icic.ocp.com"
 LOCAL_REGISTRY_PORT="5008"
-VERSION="4.8.13"
+VERSION="4.8.14"
 PULL_SECRET=''
 
-ARCH="s390x"
+CLIENT_ARCH="s390x"
+IMAGE_ARCH="s390x"
 
 if [ -z "$PULL_SECRET" ]
 then
@@ -42,25 +43,22 @@ sed -i "s/HOSTPORT/${HOSTPORT}/g" pull-secret.json
 sed -i "s/you@example.com/$REGISTRY_EMAIL/g" pull-secret.json
 
 BUILDNAME="ocp"
-#BUILDNUMBER="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/clients/${BUILDNAME}/${VERSION}/release.txt" | grep 'Name:' | awk '{print $NF}')"
-BUILDNUMBER="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/${BUILDNAME}/${VERSION}/release.txt" | grep 'Name:' | awk '{print $NF}')"
+BUILDNUMBER="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/${IMAGE_ARCH}/clients/${BUILDNAME}/${VERSION}/release.txt" | grep 'Name:' | awk '{print $NF}')"
 
 if [ "$(echo "${BUILDNUMBER}" | cut -d '.' -f1-2)" == "4.2" ] && [ "$(echo "${BUILDNUMBER}" | cut -d '.' -f3)" -lt "14" ];then
   OCP_RELEASE="${BUILDNUMBER}"
 else
-  OCP_RELEASE="${BUILDNUMBER}-${ARCH}"
+  OCP_RELEASE="${BUILDNUMBER}-${IMAGE_ARCH}"
 fi
 
 LOCAL_REGISTRY="${LOCAL_REGISTRY_HOSTNAME}:${LOCAL_REGISTRY_PORT}"
 LOCAL_REPOSITORY='icic/openshift4'
-#PRODUCT_REPO="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/clients/${BUILDNAME}/${VERSION}/release.txt" | grep "Pull From:" | cut -d '/' -f2)"
-PRODUCT_REPO="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/s390x/clients/${BUILDNAME}/${VERSION}/release.txt" | grep "Pull From:" | cut -d '/' -f2)"
+PRODUCT_REPO="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/${IMAGE_ARCH}/clients/${BUILDNAME}/${VERSION}/release.txt" | grep "Pull From:" | cut -d '/' -f2)"
 LOCAL_SECRET_JSON="./pull-secret.json"
-#RELEASE_NAME="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/clients/${BUILDNAME}/${VERSION}/release.txt" | grep "Pull From:" | cut -d '/' -f3 | cut -d '@' -f1)"
-RELEASE_NAME="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/s390x/clients/${BUILDNAME}/${VERSION}/release.txt" | grep "Pull From:" | cut -d '/' -f3 | cut -d '@' -f1)"
+RELEASE_NAME="$(curl -s "https://mirror.openshift.com/pub/openshift-v4/${IMAGE_ARCH}/clients/${BUILDNAME}/${VERSION}/release.txt" | grep "Pull From:" | cut -d '/' -f3 | cut -d '@' -f1)"
 
 # Download openshift client
-wget https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${VERSION}/openshift-client-linux.tar.gz
+wget https://mirror.openshift.com/pub/openshift-v4/${CLIENT_ARCH}/clients/ocp/${VERSION}/openshift-client-linux.tar.gz
 tar -zvxf openshift-client-linux.tar.gz
 rm -rf openshift-client-linux.tar.gz
 # Mirroring Images


### PR DESCRIPTION
Fixes implemented:
1. Removed the automatic restart of the mirror registry.
2. Supported locally stored RHCOS client and images.
3. Updated the mirror registry script to support different architectures.