### PR TITLE
[cloud_infra_center]remove etcd info in bastion and doc

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/cluster-template.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/cluster-template.yaml
@@ -14,13 +14,10 @@ cluster_nodes:
   masters:
     master-0:
       ip: '172.26.103.231'
-      etcd: etcd-0
     master-1:
       ip: '172.26.103.232'
-      etcd: etcd-1
     master-2:
       ip: '172.26.103.233'
-      etcd: etcd-2
   infra:
     worker-0:
       ip: '172.26.103.234'

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/docs/add-dns-haproxy.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/docs/add-dns-haproxy.md
@@ -19,13 +19,10 @@ cluster_nodes:
       ip: 172.26.105.211
   masters:
     master-0:
-      etcd: etcd-0
       ip: 172.26.105.200
     master-1:
-      etcd: etcd-1
       ip: 172.26.105.207
     master-2:
-      etcd: etcd-2
       ip: 172.26.105.202
 ```
 
@@ -58,14 +55,6 @@ master-2              IN A 172.26.105.202
 worker-0              IN A 172.26.105.208
 worker-1              IN A 172.26.105.209
 worker-2              IN A 172.26.105.211
-
-etcd-0              IN A 172.26.105.200
-etcd-1              IN A 172.26.105.207
-etcd-2              IN A 172.26.105.202
-
-_etcd-server-ssl._tcp IN SRV 0 10 2380 etcd-0.openshift.second.com.
-                      IN SRV 0 10 2380 etcd-1.openshift.second.com.
-                      IN SRV 0 10 2380 etcd-2.openshift.second.com.
 ```
 
 required DNS records

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/docs/multi-cluster-bastion.md
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/docs/multi-cluster-bastion.md
@@ -30,14 +30,6 @@ master-2              IN A 172.26.105.202
 
 worker-0              IN A 172.26.105.208
 worker-1              IN A 172.26.105.209
-
-etcd-0              IN A 172.26.105.200
-etcd-1              IN A 172.26.105.207
-etcd-2              IN A 172.26.105.202
-
-_etcd-server-ssl._tcp IN SRV 0 10 2380 etcd-0.openshift.second.com.
-                      IN SRV 0 10 2380 etcd-1.openshift.second.com.
-                      IN SRV 0 10 2380 etcd-2.openshift.second.com.
 ```
 
 You need to change the `openshift.second.com` to the second cluster domain name, and change servers' IPs and worker nodes' names.

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/modify-bastion.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/modify-bastion.yaml
@@ -38,14 +38,6 @@
     - new_worker_exists.stdout | int == 0
     - last_worker_ln.stdout != ""
 
-# modify dns file when there are no workers present
-- name: Add new worker dns record into named when no workers present
-  ansible.builtin.shell:
-    cmd: "sed -i '/etcd-0 /i{{ new_worker_name }}              IN A {{ new_worker_ip  }}\n' /var/named/{{ cluster_domain_name  }}.zone"
-  when:
-    - new_worker_exists.stdout | int == 0
-    - last_worker_ln.stdout == ""
-
 # modify haproxy file
 - name: 'Validation worker name exist in haproxy'
   ansible.builtin.shell: cat /etc/haproxy/haproxy.cfg | grep "{{ new_worker_name }}" | wc -l

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-dns/templates/var/named/cluster_domain_name.zone.j2
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-dns/templates/var/named/cluster_domain_name.zone.j2
@@ -27,14 +27,3 @@ apps                  IN A {{ bastion_public_ip_address }}
 {{ item }}              IN A {{ infra[item].ip }}
 {% endfor %}
 {% endif %}
-
-{% for item in masters.keys() %}
-{{ masters[item].etcd }}              IN A {{ masters[item].ip }}
-{% endfor %}
-
-_etcd-server-ssl._tcp IN SRV 0 10 2380 etcd-0.{{ cluster_name }}.{{ base_domain }}.
-{% for item in masters.keys() %}
-  {% if loop.index != 1 %}
-                  IN SRV 0 10 2380 etcd-{{(loop.index - 1) }}.{{ cluster_name }}.{{ base_domain }}.
-  {% endif %}
-{% endfor %}

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-dns/templates/var/named/cluster_domain_name.zone.j3
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-dns/templates/var/named/cluster_domain_name.zone.j3
@@ -27,17 +27,3 @@ apps                  IN A {{ bastion_public_ip_address }}
 {{ item }}              IN A {{ infra[item].ip }}
 {% endfor %}
 {% endif %}
-
-{% for item in masters.keys() %}
-{% set key = master-{{ (loop.index - 1) }} %}
-{{ key }}
-#{% set ip = master[{{ key }}].ip %}
-#etcd-{{ (loop.index - 1) }}                IN A {{ ip }}
-{% endfor %}
-
-_etcd-server-ssl._tcp IN SRV 0 10 2380 etcd-0.{{ cluster_name }}.{{ base_domain }}.
-{% for item in masters.keys() %}
-  {% if loop.index != 1 %}
-                  IN SRV 0 10 2380 etcd-{{(loop.index - 1) }}.{{ cluster_name }}.{{ base_domain }}.
-  {% endif %}
-{% endfor %}

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/modify-bastion.py
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/tools/modify-bastion.py
@@ -36,9 +36,9 @@ def get_nodes_ips(infra_id, node_role):
     """
      get nodes' IPs with different role, and return a dict like 
      {"masters": 
-     {"master-0": {"ip": "172.26.103.1", "etcd": "etcd-0"}}, 
-     {"master-1": {"ip": "172.26.103.2", "etcd": "etcd-1"}},
-     {"master-2": {"ip": "172.26.103.3", "etcd": "etcd-2"}}
+     {"master-0": {"ip": "172.26.103.1"}}, 
+     {"master-1": {"ip": "172.26.103.2"}},
+     {"master-2": {"ip": "172.26.103.3"}}
      }
     """
     cmd = "openstack --os-volume-api-version=3 port list | grep %s | awk '{print$4,$8}'" % (infra_id+"-"+node_role)
@@ -65,10 +65,7 @@ def get_nodes_ips(infra_id, node_role):
             name = n[1] + "-" + n[-1]
         ip = node.split(" ")[1]
         ip = ip.split("'")[1]
-        if node_role == "master":
-            nodes_dict[name] = {"ip": ip, "etcd": name.replace("master", "etcd")}
-        else:
-            nodes_dict[name] = {"ip": ip}
+        nodes_dict[name] = {"ip": ip}
     return nodes_dict
 
 bastion_dict = get_bastion_template()


### PR DESCRIPTION
Test okay.
```
TASK [Show openshift web-console and kubeadmin-password] *******************************************************************
ok: [localhost] => {
    "webconsole.stdout_lines": [
        "time=\"2024-08-15T00:54:32-05:00\" level=info msg=\"Install complete!\"",
        "time=\"2024-08-15T00:54:32-05:00\" level=info msg=\"To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/tmp/ocp_upi/auth/kubeconfig'\"",
        "time=\"2024-08-15T00:54:32-05:00\" level=info msg=\"Access the OpenShift web-console here: https://console-openshift-console.apps.kvm.ocp.com\"",
        "time=\"2024-08-15T00:54:32-05:00\" level=info msg=\"Login to the console with user: \\\"kubeadmin\\\", and password: \\\"FFZpE-saxGz-iGhYI-cUbBZ\\\"\"",
        "time=\"2024-08-15T00:54:32-05:00\" level=debug msg=\"Time elapsed per stage:\"",
        "time=\"2024-08-15T00:54:32-05:00\" level=debug msg=\"Cluster Operators Available: 9m6s\"",
        "time=\"2024-08-15T00:54:32-05:00\" level=info msg=\"Time elapsed: 9m7s\""
    ]
}

PLAY RECAP *****************************************************************************************************************
localhost                  : ok=15   changed=7    unreachable=0    failed=0    skipped=18   rescued=0    ignored=0
```