### PR TITLE
Make CICS doc links point to latest

### DIFF
--- a/zos_subsystems/cics/cmci/module_defaults/README.md
+++ b/zos_subsystems/cics/cmci/module_defaults/README.md
@@ -26,7 +26,7 @@ ansible-galaxy collection install ibm.ibm_zos_cics
 ```
 
 For more information about the CMCI REST API, see the
-[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/6.1?topic=fundamentals-cics-management-client-interface-cmci).
+[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/latest?topic=fundamentals-cics-management-client-interface-cmci).
 
 Because this playbook only uses the CMCI REST API, it can be run on the control node directly, without having to
 configure an inventory. Generally you'll be able to use this trick with any of the CMCI modules. In this example, we

--- a/zos_subsystems/cics/cmci/override_failure/README.md
+++ b/zos_subsystems/cics/cmci/override_failure/README.md
@@ -41,7 +41,7 @@ ansible-galaxy collection install ibm.ibm_zos_cics
 ```
 
 For more information about the CMCI REST API, see the
-[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/5.6?topic=environment-cics-management-client-interface-cmci).
+[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/latest?topic=fundamentals-cics-management-client-interface-cmci).
 
 Because this playbook only uses the CMCI REST API, it can be run on the control
 node directly, without having to configure an inventory. Generally you'll be

--- a/zos_subsystems/cics/cmci/reporting/README.md
+++ b/zos_subsystems/cics/cmci/reporting/README.md
@@ -35,7 +35,7 @@ ansible-galaxy collection install ibm.ibm_zos_cics
 ```
 
 For more information about the CMCI REST API, see the
-[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/5.6?topic=environment-cics-management-client-interface-cmci).
+[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/latest?topic=fundamentals-cics-management-client-interface-cmci).
 
 Because this playbook only uses the CMCI REST API, it can be run on the control node directly, without having to
 configure an inventory. Generally you'll be able to use this trick with any of the CMCI modules. In this example, we
@@ -82,14 +82,14 @@ the results of the report.
 - Try editing `report.yml` to change the attributes included in the report.
   
   You may want to uncomment the debug task to see the full response from CICSPlex SM, which includes all the attribute
-  names applicable to the target resource. In this example, the returned attributes will correspond to what's listed in the [CICSRGN resource table](https://www.ibm.com/docs/en/cics-ts/5.6?topic=tables-cicsrgn-resource-table). 
+  names applicable to the target resource. In this example, the returned attributes will correspond to what's listed in the [CICSRGN resource table](https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-cicsrgn-resource-table). 
   
 - Try adding a `filter` argument to the `cmci_get` task, to restrict the report to a subset of your CICS regions. For
   information on how to set a filter for the `cmci_get` task, see [the IBM z/OS CICS modules documentation](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_cics/docs/source/modules/cmci_get.html).
   
 - Try supplying a different resource for the `type` argument of the `cmci_get` task, to request attributes for a different type of resource. You can find
   available CMCI resource names at
-  [CMCI resource names](https://www.ibm.com/docs/en/cics-ts/5.6?topic=reference-cmci-resource-names).
+  [CMCI resource names](https://www.ibm.com/docs/en/cics-ts/latest?topic=reference-cmci-resource-names).
 
 - Look at the [other samples](../..) to find examples of what else you can do with the CICS collection.
 

--- a/zos_subsystems/cics/cmci/resource_lifecycle_and_csd/README.md
+++ b/zos_subsystems/cics/cmci/resource_lifecycle_and_csd/README.md
@@ -43,7 +43,7 @@ ansible-galaxy collection install ibm.ibm_zos_cics
 ```
 
 For more information about the CMCI REST API, see the
-[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/5.6?topic=environment-cics-management-client-interface-cmci).
+[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/latest?topic=fundamentals-cics-management-client-interface-cmci).
 
 Because this playbook only uses the CMCI REST API, it can be run on the control
 node directly, without having to configure an inventory. Generally you'll be
@@ -104,7 +104,7 @@ ibm.ibm_zos_cics.cmci_action:
 ```
 
 You can cross-reference this with the documentation for the
-[`PROGDEF` resource table](https://www.ibm.com/docs/en/cics-ts/5.6?topic=tables-progdef-resource-table).
+[`PROGDEF` resource table](https://www.ibm.com/docs/en/cics-ts/latest?topic=tables-progdef-resource-table).
 
 # Support
 

--- a/zos_subsystems/cics/cmci/restart_bundles/README.md
+++ b/zos_subsystems/cics/cmci/restart_bundles/README.md
@@ -33,7 +33,7 @@ ansible-galaxy collection install ibm.ibm_zos_cics
 ```
 
 For more information about the CMCI REST API, see the
-[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/5.6?topic=environment-cics-management-client-interface-cmci).
+[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/latest?topic=fundamentals-cics-management-client-interface-cmci).
 
 Because this playbook only uses the CMCI REST API, it can be run on the control node directly, without having to
 configure an inventory. Generally you'll be able to use this trick with any of the CMCI modules. In this example, we

--- a/zos_subsystems/cics/cmci/set_ca/README.md
+++ b/zos_subsystems/cics/cmci/set_ca/README.md
@@ -39,7 +39,7 @@ PEM format.  Extract your certificate and convert it to PEM format, saving it al
 side the playbook, with the name `ca_certs.pem`.
 
 For more information about the CMCI REST API, see the
-[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/5.6?topic=environment-cics-management-client-interface-cmci).
+[CMCI overview in the CICS TS documentation](https://www.ibm.com/docs/en/cics-ts/latest?topic=fundamentals-cics-management-client-interface-cmci).
 
 Because this playbook requires local access to the `ca_certs.pem` file, and only uses
 the CMCI REST API, it can be run on the control node directly, without having to


### PR DESCRIPTION
Fixes #210.

Change links to CICS documentation to point to the evergreen `latest` set of documentation.

Fix some 404s that occur when doing so.