### PR TITLE
Update security groups to include additional security groups

### DIFF
--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/tasks/main.yaml
@@ -100,8 +100,7 @@
   openstack.cloud.port:
     name: "{{ os_port_bootstrap }}"
     network: "{{ use_network_name }}"
-    security_groups:
-      - "{{ os_sg_master }}"
+    security_groups: "{{ os_sg_master + ',' + add_secgroups if add_secgroups is defined else os_sg_master }}"
     fixed_ips:
       - subnet_id: "{{ subnet_id.stdout }}"
         ip_address: "{{ os_bootstrap_ip }}"
@@ -112,8 +111,7 @@
   openstack.cloud.port:
     name: "{{ item.1 }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
-    security_groups:
-      - "{{ os_sg_master }}"
+    security_groups: "{{ os_sg_master + ',' + add_secgroups if add_secgroups is defined else os_sg_master }}"
     fixed_ips:
       - subnet_id: "{{ subnet_id.stdout }}"
         ip_address: "{{ os_master_ip[item.0] }}"
@@ -125,8 +123,7 @@
   openstack.cloud.port:
     name: "{{ item.1  }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
-    security_groups:
-      - "{{ os_sg_worker }}"
+    security_groups: "{{ os_sg_worker + ',' + add_secgroups if add_secgroups is defined else os_sg_worker }}"
     fixed_ips:
       - subnet_id: "{{ subnet_id.stdout }}"
         ip_address: "{{ os_infra_ip[item.0]}}"
@@ -138,8 +135,7 @@
   openstack.cloud.port:
     name: "{{ os_port_bootstrap }}"
     network: "{{ use_network_name }}"
-    security_groups:
-      - "{{ os_sg_master }}"
+    security_groups: "{{ os_sg_master + ',' + add_secgroups if add_secgroups is defined else os_sg_master }}"
     fixed_ips:
       - subnet_id: "{{ subnet_id.stdout }}"
   when:
@@ -149,8 +145,7 @@
   openstack.cloud.port:
     name: "{{ item.1 }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
-    security_groups:
-      - "{{ os_sg_master }}"
+    security_groups: "{{ os_sg_master + ',' + add_secgroups if add_secgroups is defined else os_sg_master }}"
     fixed_ips:
       - subnet_id: "{{ subnet_id.stdout }}"
   with_indexed_items: "{{ [os_port_master] * os_control_nodes_number }}"
@@ -161,8 +156,7 @@
   openstack.cloud.port:
     name: "{{ item.1 }}-{{ item.0 }}"
     network: "{{ use_network_name }}"
-    security_groups:
-      - "{{ os_sg_worker }}"
+    security_groups: "{{ os_sg_worker + ',' + add_secgroups if add_secgroups is defined else os_sg_worker }}"
     fixed_ips:
       - subnet_id: "{{ subnet_id.stdout }}"
   with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"


### PR DESCRIPTION
Update security groups to include additional security groups if specified using add_secgroups variable. Changes were made in configure-network role.