### PR TITLE
ACC 1.2.14 Ansible Playbooks

### DIFF
--- a/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
+++ b/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
@@ -148,7 +148,7 @@
         msg: "{{ INSTALL_SCRIPT_PATH }}"
 
     - name: Run the hmc_connected_install.sh script to install ACC (HMC connected)
-      ansible.builtin.shell: "./hmc_connected_install.sh"
+      ansible.builtin.command: "./hmc_connected_install.sh"
       args:
         chdir: "{{ INSTALL_SCRIPT_PATH }}"
       register: setup_result_connected
@@ -156,7 +156,7 @@
       when: hmc_connected | default(true) | bool
 
     - name: Run the hmc_not_connected_install.sh script to install ACC (HMC not connected)
-      ansible.builtin.shell: "./hmc_not_connected_install.sh"
+      ansible.builtin.command: "./hmc_not_connected_install.sh"
       args:
         chdir: "{{ INSTALL_SCRIPT_PATH }}"
       register: setup_result_not_connected

--- a/z_appliance_control_center/acc_install_ansible/acc_env_vars.yaml
+++ b/z_appliance_control_center/acc_install_ansible/acc_env_vars.yaml
@@ -43,7 +43,6 @@ HMC_USER: "{{ lookup('env', 'HMC_USER') }}"
 # Set Your hmc password (e.g,. export HMC_PASSWORD=<enter_hmc_password>)
 HMC_PASSWORD: "{{ lookup('env', 'HMC_PASSWORD') }}"
 
-
 ####### LPAR Credentials #######
 # Use during image installation
 # If this machine which will run the ansible playbook for ACC install
@@ -96,7 +95,7 @@ LPAR: "CC12"
 LPAR_IP: "9.x.x.x"
 
 # Disk identifier (e.g., "5f47" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 DISK_ID: "<enter_disk_id>"
 
@@ -135,7 +134,7 @@ NW_NAME: "net0"
 NW_FID: ""
 
 # CHPID
-# For DPM mode machines, provide channel-path-id 
+# For DPM mode machines, provide channel-path-id
 NW_CHPID: "d0"
 
 # Port

--- a/z_appliance_control_center/acc_install_ansible/upload_image.py
+++ b/z_appliance_control_center/acc_install_ansible/upload_image.py
@@ -68,17 +68,24 @@ def upload_zfab_image(api_token: str, disk: str, image_file: str) -> tuple[int, 
         url += f"&lun={lun}&wwpn={wwpn}"
         print(f"UPLOAD URL for FCP disk:: {url}")
 
+    # Regenerate the token to avoid token expiration
+    rc, latest_token, _ = get_api_token()
+    if rc != HTTPStatus.OK:
+        print(f"Bad rc from get_api_token: {rc}")
+        sys.exit(1)
+    print("Successfully regenerated API token before install")
+
     with open(image_file, 'rb') as payload:
         res = requests.post(
-            url, 
-            data=payload, 
+            url,
+            data=payload,
             verify=os.environ.get("VERIFY_CERT", "false").lower() == "true",
             headers={
                 "Accept": "application/vnd.ibm.zaci.payload+json;version=1.0",
                 'Content-type': "application/octet-stream",
                 'Zaci-Api': 'com.ibm.zaci.system/1.0',
-                'Authorization': f"Bearer {api_token}"
-            }, 
+                'Authorization': f"Bearer {latest_token}"
+            },
             # increased the timeout for upload image to 40 mins for safer side
             timeout=40*60
         )

--- a/z_appliance_control_center/appliance_deploy_default_ansible/01_admin_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/01_admin_actions.yaml
@@ -13,6 +13,10 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Added optional HMC credential expiry support                       |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Default playbook, run by ACC-admin, for ACC-admin actions
@@ -65,7 +69,19 @@
       private: false
       default: "yes"
 
+    - name: days_to_clear_hmc_creds
+      prompt: "Enter HMC credential expiry in days (1-14, or leave empty to skip)"
+      private: false
+      default: ""
+
   tasks:
+    - name: 00a - Validate expiry days if provided
+      ansible.builtin.fail:
+        msg: "Invalid value for days_to_clear_hmc_creds. Enter an integer from 1 to 14, or leave empty to skip."
+      when:
+        - days_to_clear_hmc_creds != ""
+        - (days_to_clear_hmc_creds is not match('^[0-9]+$') or days_to_clear_hmc_creds | int < 1 or days_to_clear_hmc_creds | int > 14)
+
     - name: 00 - Initialize ACC with HMC Default Mode
       ansible.builtin.uri:
         url: "{{ acc_url }}/init"
@@ -114,6 +130,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 03 - Set HMC configuration in the ACC (required)
       ansible.builtin.uri:
         url: "{{ acc_url }}/config/hmcconfig"
@@ -124,6 +144,7 @@
           userid: "{{ hmc_user }}"
           password: "{{ hmc_password }}"
           verify_cert: false
+          days_to_clear_hmc_creds: "{{ (days_to_clear_hmc_creds | int) if days_to_clear_hmc_creds != '' else omit }}"
         body_format: json
         headers:
           Authorization: "Bearer {{ access_token }}"

--- a/z_appliance_control_center/appliance_deploy_default_ansible/02a_assign_1_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/02a_assign_1_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-admin, for assigning one resource.
@@ -76,6 +79,10 @@
     - name: Extract the admin token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 01 - Validate WWPN and LUN values
       vars:
@@ -156,7 +163,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_default_ansible/02b_assign_2_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/02b_assign_2_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-admin, for assigning two resource.
@@ -76,6 +79,10 @@
     - name: Extract the admin token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 01 - Validate WWPN and LUN values
       vars:
@@ -163,7 +170,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_default_ansible/03_owner_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/03_owner_actions.yaml
@@ -13,6 +13,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-owner, for ACC-owner actions
@@ -89,6 +92,10 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 02 - Upload appliance image to the ACC as owner
       tags: owner

--- a/z_appliance_control_center/appliance_deploy_default_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/04_install_flow.yaml
@@ -14,6 +14,13 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Updated task ID extraction to support both 'task-id' and           |
+# *|     'task_id' formats for backward/forward compatibility               |
+# *|   - Added automatic rollback debug messages when activation fails.     |
+# *|   - Added support for fast activate mode                               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-owner, for ACC-owner actions
@@ -23,10 +30,48 @@
     - owner_vars.yaml
 
   pre_tasks:
-    - name: Reminder - Export appliance-owner credentials
+    - name: Prompt user to select activation mode
       ansible.builtin.pause:
         prompt: |
-          Before running this playbook, please export credentials:
+
+          ╔════════════════════════════════════════════════════════════════╗
+          ║          ACC Appliance Activation Mode Selection               ║
+          ╚════════════════════════════════════════════════════════════════╝
+
+          Please select the activation mode:
+
+          1. INSTALL/ACTIVATE (Regular Mode)
+             - Install a new image or activate with new configuration
+             - Requires: image_id, cores, memory, processor settings,
+                        hostname, username, password
+             - Uses: /cluster/activate endpoint
+
+          2. FAST ACTIVATE (Quick Reactivation)
+             - Reactivate previously deactivated appliances
+             - Uses preserved configuration from last activation
+             - Requires: Only LPAR names and image_match_check boolean value(default = True)
+             - Uses: /cluster/inactive-appliance/fast-activate endpoint
+
+          Enter your choice (1 or 2)
+      register: mode_selection
+
+    - name: Set activation mode based on user input
+      ansible.builtin.set_fact:
+        use_fast_activate: "{{ mode_selection.user_input | trim == '2' }}"
+
+    - name: Display selected mode
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          ✅ Selected: FAST ACTIVATE mode
+          {% else %}
+          ✅ Selected: INSTALL/ACTIVATE mode
+          {% endif %}
+
+    - name: Reminder - Export appliance-owner credentials (Install Mode)
+      ansible.builtin.pause:
+        prompt: |
+          Before continuing, please export credentials:
 
           export ACC_OWNER_PASSWORD=<owner_new_password>
           export APP_USERNAME=<appliance_username>
@@ -35,8 +80,24 @@
           Press Ctrl+C now to cancel if you haven't done this.
           The playbook will continue shortly.
         seconds: 5
+      when: not use_fast_activate
 
-    - name: Check required environment variables
+    - name: Reminder - Export appliance-owner credentials (Fast Activate Mode)
+      ansible.builtin.pause:
+        prompt: |
+          Before continuing, please export credentials:
+
+          export ACC_OWNER_PASSWORD=<owner_new_password>
+
+          Note: Fast activate mode uses preserved configuration.
+          APP_USERNAME and APP_PASSWORD are not required.
+
+          Press Ctrl+C now to cancel if you haven't done this.
+          The playbook will continue shortly.
+        seconds: 5
+      when: use_fast_activate
+
+    - name: Check required environment variables (Install Mode)
       vars:
         required_env_vars:
           - ACC_OWNER_PASSWORD
@@ -45,8 +106,13 @@
 
       ansible.builtin.fail:
         msg: "Missing required environment variable: {{ item }}"
-      when: lookup('env', item) == ""
+      when: lookup('env', item) == "" and not use_fast_activate
       loop: "{{ required_env_vars }}"
+
+    - name: Check required environment variables (Fast Activate Mode)
+      ansible.builtin.fail:
+        msg: "Missing required environment variable: ACC_OWNER_PASSWORD"
+      when: lookup('env', 'ACC_OWNER_PASSWORD') == "" and use_fast_activate
 
   tasks:
     - name: 00 - Get authentication token from the ACC as appliance-owner
@@ -67,13 +133,25 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
-    - name: Printing the image ID
-      tags: owner, install
-      ansible.builtin.debug:
-        msg: "{{ image_id }}"
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
-    - name: 01 - As owner, install and activate the image
-      tags: owner
+    - name: Display mode information
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          🚀 Running in FAST ACTIVATE mode
+          - Using preserved configuration from previous activation
+          - Endpoint: /cluster/inactive-appliance/fast-activate
+          {% else %}
+          📦 Running in INSTALL/ACTIVATE mode
+          - Using image_id: {{ image_id }}
+          - Endpoint: /cluster/activate
+          {% endif %}
+
+    - name: 01 - As owner, install and activate the image (Regular Mode)
+      tags: owner, install
       ansible.builtin.uri:
         url: "{{ acc_url }}/cluster/activate"
         method: POST
@@ -93,12 +171,12 @@
                   {
                     "name": "{{ lpar1_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install }}
                   },
                   {
                     "name": "{{ lpar2_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install }}
                   }
                 ]
               }
@@ -109,7 +187,42 @@
           Content-Type: application/json
         status_code: [200, 207]
         validate_certs: false
+      when: not use_fast_activate
       register: activate_response
+
+    - name: 01 - As owner, fast activate the appliance from preserved state (Fast Activate Mode)
+      tags: owner, fast_activate
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/inactive-appliance/fast-activate"
+        method: POST
+        body: |
+          {
+            "{{ package_name }}":
+            {
+              "lpars": [
+                  {
+                    "name": "{{ lpar1_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  },
+                  {
+                    "name": "{{ lpar2_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  }
+                ]
+              }
+            }
+        body_format: json
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Content-Type: application/json
+        status_code: [200, 207]
+        validate_certs: false
+      when: use_fast_activate
+      register: fast_activate_response
+
+    - name: Set activate_response for unified processing
+      ansible.builtin.set_fact:
+        activate_response: "{{ fast_activate_response if use_fast_activate else activate_response }}"
 
     - name: Debug message for partial failure (207)
       tags: owner, install
@@ -134,12 +247,17 @@
             activate_response.json
             | dict2items
             | map(attribute='value')
+            | select('mapping')
             | map('dict2items')
             | flatten
             | map(attribute='value')
-            | selectattr('task-id', 'defined')
-            | map(attribute='task-id')
+            | select('mapping')
+            | map('dict2items')
+            | flatten
+            | selectattr('key', 'in', ['task-id', 'task_id'])
+            | map(attribute='value')
             | list
+            | default([])
           }}
 
     - name: Print extracted task IDs
@@ -172,15 +290,15 @@
         headers:
           Authorization: "Bearer {{ access_token }}"
         validate_certs: false
-        return_content: yes
+        return_content: true
       loop: "{{ task_ids }}"
       loop_control:
         label: "Task {{ item }}"
       register: poll_status
-      retries: 45       # max retries
-      delay: 40         # wait between retries
+      retries: 45 # max retries
+      delay: 40 # wait between retries
       until: poll_status.json["action-status"] in ["Success", "Failed"]
-      failed_when: false 
+      failed_when: false
 
     - name: Evaluate all task results
       ansible.builtin.set_fact:
@@ -191,11 +309,45 @@
             | map(attribute='item')
             | list
           }}
+        acc_failed_lpars: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json.lpar')
+            | list
+          }}
+        acc_failed_task_details: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json')
+            | list
+          }}
+
+    - name: Debug message - Automatic rollback information
+      ansible.builtin.debug:
+        msg: |
+          ⚠️  {{ 'FAST ACTIVATE' if use_fast_activate else 'ACTIVATION' }} FAILED - AUTOMATIC ROLLBACK IN PROGRESS ⚠️
+
+          One or more activation tasks have failed.
+          Failed Task IDs: {{ acc_failed_tasks }}
+
+          NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
+    - name: "FAILED - Task Details"
+      ansible.builtin.debug:
+        var: acc_failed_task_details
+      when: acc_failed_tasks | length > 0
+
     - name: Fail play if any task failed
       ansible.builtin.fail:
-        msg: "❌ One or more ACC install tasks failed. Failed Task IDs: {{ acc_failed_tasks }}"
+        msg: >-
+          ❌ One or more ACC install tasks failed. Failed Task IDs:
+          {{ acc_failed_tasks }}. ACC has automatically rolled back
+          LPAR(s) {{ acc_failed_lpars | join(', ') }} to deactivate state.
       when: acc_failed_tasks | length > 0
-   
+
     - name: "Success message if both completed"
       ansible.builtin.debug:
         msg: "✅ Both tasks finished successfully or one succeeded and the other failed."

--- a/z_appliance_control_center/appliance_deploy_default_ansible/README.md
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/README.md
@@ -14,6 +14,11 @@ These sample playbooks:
 - ACC can communicate with the HMC over the network.
 - MFA is disabled in ACC by the ACC-admin.
 
+### Features
+
+- **Execution Timestamp and ACC About Info Display**: All playbooks (`01_admin_actions.yaml`, `02a_assign_1_lpar.yaml`, `02b_assign_2_lpar.yaml`, `03_owner_actions.yaml`, `04_install_flow.yaml`) now display execution timestamp and ACC about information at the start of execution for better tracking and debugging.
+- **Fast Activate Support**: The `04_install_flow.yaml` playbook now supports fast activate mode for quick reactivation of previously deactivated appliances.
+
 ## Setting Up ACC - 01_admin_actions.yaml
 
 To set up the ACC, the following actions must be performed by the ACC-admin on
@@ -197,6 +202,26 @@ assigned to the appliance-owner are **deactivated**.
 Once the appliance-owner has performed the actions above, the appliance-owner can
 install the appliance. For that, perform the following actions as appliance-owner.
 
+### Activation Mode Selection
+
+The playbook now supports two activation modes:
+
+1. **INSTALL/ACTIVATE (Regular Mode)**:
+   - Install a new image or activate with new configuration
+   - Requires: image_id, cores, memory, processor settings, hostname, username, password
+   - Uses: `/cluster/activate` endpoint
+
+2. **FAST ACTIVATE (Quick Reactivation)**:
+   - Reactivate previously deactivated appliances
+   - Uses preserved configuration from last activation
+   - Requires: Only LPAR names and image_match_check boolean value (default = True)
+   - Uses: `/cluster/inactive-appliance/fast-activate` endpoint
+   - **Note**: For fast activate mode, only `ACC_OWNER_PASSWORD` is required. `APP_USERNAME` and `APP_PASSWORD` are not needed as the preserved configuration is used.
+
+When you run the playbook, you will be prompted to select the activation mode (1 or 2).
+
+### Installation Steps
+
 - In case the admin has only assigned a single LPAR using the
   `02a_assign_1_lpar.yaml` playbook, then remove the second LPAR's details in
   task `01 - As owner, install and activate the image` of `04_install_flow.yaml`.
@@ -213,15 +238,11 @@ install the appliance. For that, perform the following actions as appliance-owne
   ```
 
   Note that you will have to remove any trailing commas in the JSON object.
-- Export the newly set appliance-owner password in a terminal on your control node (laptop):
+
+- **For INSTALL/ACTIVATE mode**, export the newly set appliance-owner password and appliance credentials:
 
   ```bash
   export ACC_OWNER_PASSWORD=<owner_new_password>
-  ```
-
-- Export and set a new username and password to be used for the appliance LPAR(s):
-
-  ```bash
   export APP_USERNAME=<appliance_username>
   export APP_PASSWORD=<appliance_password>
   ```
@@ -231,16 +252,23 @@ install the appliance. For that, perform the following actions as appliance-owne
 
   Note: You will have to follow the administrator user id and password guidelines defined in the
   [SSC user-guide](https://www.ibm.com/docs/en/systems-hardware/zsystems/9175-ME1?topic=wsscpsms-changing-logon-settings-secure-service-container-partition-standard-mode-system).
+
+- **For FAST ACTIVATE mode**, only export the appliance-owner password:
+
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_new_password>
+  ```
+
 - `cd` to the directory `appliance_deploy_default_ansible`.
 - Modify the remaining owner variables not updated during [03 playbook execution](#appliance-installation---preparations---03_owner_actionsyaml) in the file `owner_vars.yaml`.
+  - For fast activate mode, you can optionally set `image_match_check` variable (default is `true`).
 
 - Run the playbook:
 
   ```bash
   ansible-playbook 04_install_flow.yaml
   ```
-
-The above playbook with send the install command to ACC. ACC will take up to
+The above playbook will send the install command to ACC. ACC will take up to
 20 mins to install the appliance. Check the status of the appliances on HMC and wait for the playbook to complete successfully.
 
 Note that to pull logs for appliances, concurrent updates for appliances, upgrade, health check

--- a/z_appliance_control_center/appliance_deploy_default_ansible/README.md
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/README.md
@@ -27,6 +27,12 @@ their control node.
   ```
 
   Here, ACC-admin should use the credentials with which ACC will access the HMC.
+
+  **Optional:** During playbook execution, you will be prompted to set an HMC credential
+  expiry time. Enter a number between 1-14 to set credentials to expire after that many
+  days. On leaving empty we do not pass credential expiry time and hence ACC takes the
+  default expiry of 1 day. This enhances security by ensuring credentials are refreshed
+  regularly.
 - Export the ACC-admin username and default password. Additionally, set and
   export a new password for the ACC admin and a default password for the ACC
   owner. Keep in mind, the ACC API will be used to set these new passwords for

--- a/z_appliance_control_center/appliance_deploy_default_ansible/admin_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/admin_vars.yaml
@@ -11,6 +11,8 @@
 # *|     hmc_managed by acc_default_mode                                    |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
 
 #####################################################################################################
@@ -27,7 +29,6 @@
 #   - FID          -> choose NETH
 ######################################################################################################
 
-
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
 
@@ -35,7 +36,6 @@ acc_url: https://9.120.0.0:8081/api
 
 # Initialize the ACC with default mode (acc_default_mode: true) or standalone mode (acc_default_mode: false)
 acc_default_mode: true
-
 
 ####### HMC access #######
 
@@ -49,7 +49,6 @@ hmc_user: "{{ lookup('env', 'HMC_USER') }}"
 # ACC-admin's password on the HMC (e.g., passw0rd123)
 # Export before run: export HMC_PASSWORD=<your_hmc_password>
 hmc_password: "{{ lookup('env', 'HMC_PASSWORD') }}"
-
 
 ####### Users #######
 
@@ -95,9 +94,7 @@ cc_owner_email: "cc_owner@email.com"
 # Export before run: export ACC_OWNER_DEFAULT_PASSWORD=<owner_default_password>
 cc_owner_default_password: "{{ lookup('env', 'ACC_OWNER_DEFAULT_PASSWORD') }}" # Specify default password for Owner's creation (e.g., "defaultP@ssw0rd")
 
-
 ####### Resources that are assigned to the appliance-owner #######
-
 
 ###########################################################################################
 # A *resource package* is a bundle of hardware resources assigned to a
@@ -110,7 +107,7 @@ cc_owner_default_password: "{{ lookup('env', 'ACC_OWNER_DEFAULT_PASSWORD') }}" #
 # the owner_vars file will be drawn from the total resources specified in the resource package.
 # ------------------------------------------------------------------------------
 #
-# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR. 
+# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR.
 # For better performance, more resource can be assigned depending on the expected workload.
 #
 # Memory should always be a multiple of 1024 (1 GB).
@@ -130,7 +127,6 @@ package_gps: 6
 
 # Memory allocated for resource creation (in MB): depends on the CPC's customerStorageAvailable, it should be multiple of 1024.
 package_memory_mb: 163840
-
 
 ################################################################################
 # How to use this configuration file for Resource Package creation
@@ -165,7 +161,7 @@ prefix1: 23
 vlan1_id: 300
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk1_id: "0.0.5abc"
 
@@ -192,7 +188,6 @@ chpid1: "d0"
 # Port number for the lpar (0 or 1), if CHIP ID available then only port can be added
 zport1: 0
 
-
 ####### Second LPAR Configuration #######
 
 # Logical partition (LPAR) name for resource assignment (e.g., "BLUEC1") should be valid SSA lpar name
@@ -211,7 +206,7 @@ prefix2: 23
 vlan2_id: 30
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk2_id: "0.0.5abc"
 
@@ -220,11 +215,11 @@ is_fcp2: false
 
 # World Wide Port Name (WWPN) To be added only when is_fcp is true
 # Should be 16 digits
-wwpn1: "5000000000000001"
+wwpn2: "5000000000000001"
 
 # Logical Unit Number (LUN) To be added only when is_fcp is true
 # Should be 16 digits
-lun1: "7000000000000001"
+lun2: "7000000000000001"
 
 # Appliance IP address ( lpar ip)
 app2_ip: "9.x.x.x"

--- a/z_appliance_control_center/appliance_deploy_default_ansible/owner_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/owner_vars.yaml
@@ -10,7 +10,28 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
+
+###########################################################################################
+# Important Notes:  FAST ACTIVATE
+#
+# 1. Fast activate only works for LPARs that have been previously activated and then
+#    deactivated. ACC uses the preserved data from the last activation.
+#
+# 2. No image_id, cores, memory, processor_type, processor_usage, hostname, username,
+#    or password parameters are needed - these are all retrieved from preserved state.
+#
+# 3. The execution_action is automatically determined:
+#    - "default" for preserved (deactivated) LPARs
+#    - "appliance_only" for active LPARs in installer mode
+#
+# 4. The install parameter is always set to False for fast activate.
+#
+# 5. Set image_match_check to true (recommended) to ensure the preserved image matches
+#    the current image in the system, or false to skip validation.
+###########################################################################################
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
@@ -144,6 +165,15 @@ app_cores: 2
 # This value represents the memory assigned to each appliance LPAR.
 app_memory: 51200
 
+# image_match_check
+
+# Controls whether to verify that the preserved image matches the current image.
+# - true: Validates that the image used during previous activation matches the
+#         current image in the ACC. Recommended for safety.
+# - false: Skips image validation.
+# Default: true
+
+image_match_check: true
 
 ####### Appliance credential #######
 
@@ -157,7 +187,7 @@ app_memory: 51200
 # Secure Service Container graphical user interface (GUI). An administrator user ID can
 # be 1 - 32 characters long. It cannot contain blanks. Valid characters are numbers
 # 0 - 9, letters A - Z (upper or lower case), and the following special
-# characters: period (.), underscore (_), and hyphen (-). 
+# characters: period (.), underscore (_), and hyphen (-).
 # APP_PASSWORD: This is the Administrator password in the SSC user guide.
 # This password can have a minimum of 8 characters and a maximum of 256 characters.
 # An administrator password is case-sensitive and can contain numbers 0 - 9, letters A - Z
@@ -176,13 +206,11 @@ app_username: "{{ lookup('env', 'APP_USERNAME') }}"
 # Export before run: export APP_PASSWORD=<appliance_password>
 app_password: "{{ lookup('env', 'APP_PASSWORD') }}"
 
-
 ####### Available execution mode #######
 
 # . For default ACC (i.e, hmc_managed=true): "default", "prep_lpar_only", "appliance_only", "switch_to_installer"
 # . Standalone ACC (i.e, hmc_managed=false): "appliance_only", "switch_to_installer"
 execution_action: "default"
-
 
 ####################################################################################################################
 # In HMC, go to Customize Image Profile, navigate to the Processor section and check the processor type and value,
@@ -197,8 +225,8 @@ execution_action: "default"
 # otherwise set it to "general-purpose" for central processors
 # Set processor_type for the LPAR (used during image installation)
 # Keep in mind, the processor type defined here correlates to the min_ifl value defined earlier.
-#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance. 
-#     If min_ifls is set to 2 and processor_type is "general-purpose", then 2 gps will be assigned as the minimum for the appliance. 
+#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance.
+#     If min_ifls is set to 2 and processor_type is "general-purpose", then 2 gps will be assigned as the minimum for the appliance.
 processor_type: "general-purpose"
 
 # Set "processor_usage" to "shared" if the processor in the image profile is "not dedicated", and "dedicated" if it is dedicated.

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/01_admin_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/01_admin_actions.yaml
@@ -13,6 +13,10 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Added optional HMC credential expiry support                       |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Default playbook with MFA enabled, run by ACC-admin, for ACC-admin actions
@@ -65,7 +69,19 @@
       private: false
       default: "yes"
 
+    - name: days_to_clear_hmc_creds
+      prompt: "Enter HMC credential expiry in days (1-14, or leave empty to skip)"
+      private: false
+      default: ""
+
   tasks:
+    - name: 00a - Validate expiry days if provided
+      ansible.builtin.fail:
+        msg: "Invalid value for days_to_clear_hmc_creds. Enter an integer from 1 to 14, or leave empty to skip."
+      when:
+        - days_to_clear_hmc_creds != ""
+        - (days_to_clear_hmc_creds is not match('^[0-9]+$') or days_to_clear_hmc_creds | int < 1 or days_to_clear_hmc_creds | int > 14)
+
     - name: 00 - Initialize ACC with HMC Default mode with MFA
       ansible.builtin.uri:
         url: "{{ acc_url }}/init"
@@ -98,7 +114,7 @@
       ansible.builtin.pause:
         prompt: "Enter OTP generated from the above totp_secret:"
       register: otp_input
-      when: run_init | lower == "yes"
+      when: (run_init | lower == "yes") or (update_pass | lower == "yes")
 
     - name: 01 - Update ACC-admin password
       ansible.builtin.uri:
@@ -158,6 +174,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 03 - Set HMC configuration in the ACC (required)
       ansible.builtin.uri:
         url: "{{ acc_url }}/config/hmcconfig"
@@ -168,6 +188,7 @@
           userid: "{{ hmc_user }}"
           password: "{{ hmc_password }}"
           verify_cert: false
+          days_to_clear_hmc_creds: "{{ (days_to_clear_hmc_creds | int) if days_to_clear_hmc_creds != '' else omit }}"
         body_format: json
         headers:
           Authorization: "Bearer {{ access_token }}"

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/02a_assign_1_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/02a_assign_1_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-admin, for assigning one resource.
@@ -83,6 +86,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 01 - Validate WWPN and LUN values
       vars:
         hex_pattern: "^[A-Fa-f0-9]{16}$"
@@ -109,7 +116,6 @@
             - item | length > 0
             - item is not match(hex_pattern)
           loop: "{{ lun_vars }}"
-
 
     - name: 02 - As ACC-admin, assign single LPAR to the owner
       block:
@@ -163,7 +169,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/02b_assign_2_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/02b_assign_2_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-admin, for assigning two resource.
@@ -78,6 +81,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 01 - Validate WWPN and LUN values
       vars:
         hex_pattern: "^[A-Fa-f0-9]{16}$"
@@ -106,7 +113,6 @@
             - item | length > 0
             - item is not match(hex_pattern)
           loop: "{{ lun_vars }}"
-
 
     - name: 02 - As ACC-admin, assign two LPARs to the owner
       block:
@@ -165,7 +171,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/03_owner_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/03_owner_actions.yaml
@@ -13,6 +13,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-owner, for ACC-owner actions
@@ -26,7 +29,6 @@
       prompt: "Do you want to update the owner password? If you have already, then please type no (yes/no)"
       private: false
       default: "yes"
-
 
   pre_tasks:
     - name: Reminder - Export appliance-owner credentials
@@ -178,6 +180,11 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
 
     - name: 04 - Upload appliance image to the ACC as owner
       tags: owner

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/04_install_flow.yaml
@@ -14,6 +14,13 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Updated task ID extraction to support both 'task-id' and           |
+# *|     'task_id' formats for backward/forward compatibility               |
+# *|   - Added automatic rollback debug messages when activation fails.     |
+# *|   - Added support for fast activate mode                               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-owner, for ACC-owner actions
@@ -23,10 +30,48 @@
     - owner_vars.yaml
 
   pre_tasks:
-    - name: Reminder - Export appliance-owner credentials
+    - name: Prompt user to select activation mode
       ansible.builtin.pause:
         prompt: |
-          Before running this playbook, please export credentials:
+
+          ╔════════════════════════════════════════════════════════════════╗
+          ║          ACC Appliance Activation Mode Selection               ║
+          ╚════════════════════════════════════════════════════════════════╝
+
+          Please select the activation mode:
+
+          1. INSTALL/ACTIVATE (Regular Mode)
+             - Install a new image or activate with new configuration
+             - Requires: image_id, cores, memory, processor settings,
+                        hostname, username, password
+             - Uses: /cluster/activate endpoint
+
+          2. FAST ACTIVATE (Quick Reactivation)
+             - Reactivate previously deactivated appliances
+             - Uses preserved configuration from last activation
+             - Requires: Only LPAR names and image_match_check boolean value(default = True)
+             - Uses: /cluster/inactive-appliance/fast-activate endpoint
+
+          Enter your choice (1 or 2)
+      register: mode_selection
+
+    - name: Set activation mode based on user input
+      ansible.builtin.set_fact:
+        use_fast_activate: "{{ mode_selection.user_input | trim == '2' }}"
+
+    - name: Display selected mode
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          ✅ Selected: FAST ACTIVATE mode
+          {% else %}
+          ✅ Selected: INSTALL/ACTIVATE mode
+          {% endif %}
+
+    - name: Reminder - Export appliance-owner credentials (Install Mode)
+      ansible.builtin.pause:
+        prompt: |
+          Before continuing, please export credentials:
 
           export ACC_OWNER_PASSWORD=<owner_new_password>
           export APP_USERNAME=<appliance_username>
@@ -35,8 +80,24 @@
           Press Ctrl+C now to cancel if you haven't done this.
           The playbook will continue shortly.
         seconds: 5
+      when: not use_fast_activate
 
-    - name: Check required environment variables
+    - name: Reminder - Export appliance-owner credentials (Fast Activate Mode)
+      ansible.builtin.pause:
+        prompt: |
+          Before continuing, please export credentials:
+
+          export ACC_OWNER_PASSWORD=<owner_new_password>
+
+          Note: Fast activate mode uses preserved configuration.
+          APP_USERNAME and APP_PASSWORD are not required.
+
+          Press Ctrl+C now to cancel if you haven't done this.
+          The playbook will continue shortly.
+        seconds: 5
+      when: use_fast_activate
+
+    - name: Check required environment variables (Install Mode)
       vars:
         required_env_vars:
           - ACC_OWNER_PASSWORD
@@ -45,8 +106,13 @@
 
       ansible.builtin.fail:
         msg: "Missing required environment variable: {{ item }}"
-      when: lookup('env', item) == ""
+      when: lookup('env', item) == "" and not use_fast_activate
       loop: "{{ required_env_vars }}"
+
+    - name: Check required environment variables (Fast Activate Mode)
+      ansible.builtin.fail:
+        msg: "Missing required environment variable: ACC_OWNER_PASSWORD"
+      when: lookup('env', 'ACC_OWNER_PASSWORD') == "" and use_fast_activate
 
   tasks:
     - name: Wait for user to generate OTP using Owner mfa secret
@@ -73,13 +139,33 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
+
+    - name: Display mode information
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          🚀 Running in FAST ACTIVATE mode
+          - Using preserved configuration from previous activation
+          - Endpoint: /cluster/inactive-appliance/fast-activate
+          {% else %}
+          📦 Running in INSTALL/ACTIVATE mode
+          - Using image_id: {{ image_id }}
+          - Endpoint: /cluster/activate
+          {% endif %}
+
     - name: Printing the image ID
       tags: owner, install
       ansible.builtin.debug:
         msg: "{{ image_id }}"
+      when: not use_fast_activate
 
-    - name: 01 - As owner, install and activate the image
+    - name: 01 - As owner, install and activate the image (Regular Mode)
       tags: owner
+      when: not use_fast_activate
       ansible.builtin.uri:
         url: "{{ acc_url }}/cluster/activate"
         method: POST
@@ -117,6 +203,40 @@
         validate_certs: false
       register: activate_response
 
+    - name: 01 - As owner, fast activate the appliance from preserved state (Fast Activate Mode)
+      tags: owner, fast_activate
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/inactive-appliance/fast-activate"
+        method: POST
+        body: |
+          {
+            "{{ package_name }}":
+            {
+              "lpars": [
+                  {
+                    "name": "{{ lpar1_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  },
+                  {
+                    "name": "{{ lpar2_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  }
+                ]
+              }
+            }
+        body_format: json
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Content-Type: application/json
+        status_code: [200, 207]
+        validate_certs: false
+      when: use_fast_activate
+      register: fast_activate_response
+
+    - name: Set activate_response for unified processing
+      ansible.builtin.set_fact:
+        activate_response: "{{ fast_activate_response if use_fast_activate else activate_response }}"
+
     - name: Debug message for partial failure (207)
       tags: owner, install
       ansible.builtin.debug:
@@ -140,12 +260,17 @@
             activate_response.json
             | dict2items
             | map(attribute='value')
+            | select('mapping')
             | map('dict2items')
             | flatten
             | map(attribute='value')
-            | selectattr('task-id', 'defined')
-            | map(attribute='task-id')
+            | select('mapping')
+            | map('dict2items')
+            | flatten
+            | selectattr('key', 'in', ['task-id', 'task_id'])
+            | map(attribute='value')
             | list
+            | default([])
           }}
 
     - name: Print extracted task IDs
@@ -172,15 +297,15 @@
         headers:
           Authorization: "Bearer {{ access_token }}"
         validate_certs: false
-        return_content: yes
+        return_content: true
       loop: "{{ task_ids }}"
       loop_control:
         label: "Task {{ item }}"
       register: poll_status
-      retries: 45       # max retries
-      delay: 40         # wait between retries
+      retries: 45 # max retries
+      delay: 40 # wait between retries
       until: poll_status.json["action-status"] in ["Success", "Failed"]
-      failed_when: false 
+      failed_when: false
 
     - name: Evaluate all task results
       ansible.builtin.set_fact:
@@ -191,11 +316,45 @@
             | map(attribute='item')
             | list
           }}
+        acc_failed_lpars: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json.lpar')
+            | list
+          }}
+        acc_failed_task_details: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json')
+            | list
+          }}
+
+    - name: Debug message - Automatic rollback information
+      ansible.builtin.debug:
+        msg: |
+          ⚠️  {{ 'FAST ACTIVATE' if use_fast_activate else 'ACTIVATION' }} FAILED - AUTOMATIC ROLLBACK IN PROGRESS ⚠️
+
+          One or more activation tasks have failed.
+          Failed Task IDs: {{ acc_failed_tasks }}
+
+          NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
+    - name: "FAILED - Task Details"
+      ansible.builtin.debug:
+        var: acc_failed_task_details
+      when: acc_failed_tasks | length > 0
+
     - name: Fail play if any task failed
       ansible.builtin.fail:
-        msg: "❌ One or more ACC install tasks failed. Failed Task IDs: {{ acc_failed_tasks }}"
+        msg: >-
+          ❌ One or more ACC install tasks failed. Failed Task IDs:
+          {{ acc_failed_tasks }}. ACC has automatically rolled back
+          LPAR(s) {{ acc_failed_lpars | join(', ') }} to deactivate state.
       when: acc_failed_tasks | length > 0
-   
+
     - name: "Success message if both completed"
       ansible.builtin.debug:
         msg: "✅ Both tasks finished successfully or one succeeded and the other failed."

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/README.md
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/README.md
@@ -16,6 +16,11 @@ These sample playbooks:
 - In these playbooks, the MFA enablement done during the
   initialization of ACC.
 
+### Features
+
+- **Execution Timestamp and ACC About Info Display**: All playbooks (`01_admin_actions.yaml`, `02a_assign_1_lpar.yaml`, `02b_assign_2_lpar.yaml`, `03_owner_actions.yaml`, `04_install_flow.yaml`) now display execution timestamp and ACC about information at the start of execution for better tracking and debugging.
+- **Fast Activate Support**: The `04_install_flow.yaml` playbook now supports fast activate mode for quick reactivation of previously deactivated appliances.
+
 ## Setting Up ACC - 01_admin_actions.yaml
 
 To set up the ACC, the following actions must be performed by the ACC-admin on
@@ -235,6 +240,26 @@ Note: To generate the access token for the owner, provide the OTP when prompted 
 Use the last saved mfa_secret of owner to generate this OTP through your authenticator app.
 When the command prompt requests an OTP, enter the OTP generated using the saved mfa_secret.
 
+### Activation Mode Selection
+
+The playbook now supports two activation modes:
+
+1. **INSTALL/ACTIVATE (Regular Mode)**:
+   - Install a new image or activate with new configuration
+   - Requires: image_id, cores, memory, processor settings, hostname, username, password
+   - Uses: `/cluster/activate` endpoint
+
+2. **FAST ACTIVATE (Quick Reactivation)**:
+   - Reactivate previously deactivated appliances
+   - Uses preserved configuration from last activation
+   - Requires: Only LPAR names and image_match_check boolean value (default = True)
+   - Uses: `/cluster/inactive-appliance/fast-activate` endpoint
+   - **Note**: For fast activate mode, only `ACC_OWNER_PASSWORD` is required. `APP_USERNAME` and `APP_PASSWORD` are not needed as the preserved configuration is used.
+
+When you run the playbook, you will be prompted to select the activation mode (1 or 2).
+
+### Installation Steps
+
 - In case the admin has only assigned a single LPAR using the
   `02a_assign_1_lpar.yaml` playbook, then remove the second LPAR's details in
   task `01 - As owner, install and activate the image` of `04_install_flow.yaml`.
@@ -251,15 +276,11 @@ When the command prompt requests an OTP, enter the OTP generated using the saved
   ```
 
   Note that you will have to remove any trailing commas in the JSON object.
-- Export the newly set appliance-owner password in a terminal on your control node (laptop):
+
+- **For INSTALL/ACTIVATE mode**, export the newly set appliance-owner password and appliance credentials:
 
   ```bash
   export ACC_OWNER_PASSWORD=<owner_new_password>
-  ```
-
-- Export and set a new username and password to be used for the appliance LPAR(s):
-
-  ```bash
   export APP_USERNAME=<appliance_username>
   export APP_PASSWORD=<appliance_password>
   ```
@@ -267,10 +288,18 @@ When the command prompt requests an OTP, enter the OTP generated using the saved
   `appliance_username` and `appliance_passwords` are the credentials of the SSC LPAR (appliance)
   that will be installed by ACC.
 
-    Note: You will have to follow the administrator user id and password guidelines defined in the
+  Note: You will have to follow the administrator user id and password guidelines defined in the
   [SSC user-guide](https://www.ibm.com/docs/en/systems-hardware/zsystems/9175-ME1?topic=wsscpsms-changing-logon-settings-secure-service-container-partition-standard-mode-system).
+
+- **For FAST ACTIVATE mode**, only export the appliance-owner password:
+
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_new_password>
+  ```
+
 - `cd` to the directory `appliance_deploy_default_mfa_ansible`.
 - Modify the variables in the file `owner_vars.yaml`.
+  - For fast activate mode, you can optionally set `image_match_check` variable (default is `true`).
 
 - Run the playbook:
 
@@ -278,7 +307,7 @@ When the command prompt requests an OTP, enter the OTP generated using the saved
   ansible-playbook 04_install_flow.yaml
   ```
 
-The above playbook with send the install command to ACC. ACC will take up to
+The above playbook will send the install command to ACC. ACC will take up to
 20 mins to install the appliance. Check the status of the appliances on HMC and wait for the playbook to complete successfully.
 
 Note that to pull logs for appliances, concurrent updates for appliances, upgrade, health check

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/README.md
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/README.md
@@ -28,6 +28,12 @@ their control node.
   export HMC_PASSWORD=<enter_HMC_password>
   ```
 
+  **Optional:** During playbook execution, you will be prompted to set an HMC credential
+  expiry time. Enter a number between 1-14 to set credentials to expire after that many
+  days. On leaving empty we do not pass credential expiry time and hence ACC takes the
+  default expiry of 1 day. This enhances security by ensuring credentials are refreshed
+  regularly.
+
 - Export the ACC-admin username and default password. Additionally, set and
   export a new password for the ACC admin and a default password for the ACC
   owner. Keep in mind, the ACC API will be used to set these new passwords for

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/admin_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/admin_vars.yaml
@@ -11,6 +11,8 @@
 # *|     hmc_managed by acc_default_mode                                    |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
 
 #####################################################################################################
@@ -27,7 +29,6 @@
 #   - FID          -> choose NETH
 ######################################################################################################
 
-
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
 
@@ -38,7 +39,6 @@ acc_default_mode: true
 
 # Enable or disable Multi-Factor Authentication (true/false)
 mfa_enabled: true
-
 
 ####### HMC access #######
 
@@ -52,7 +52,6 @@ hmc_user: "{{ lookup('env', 'HMC_USER') }}"
 # ACC-admin's password on the HMC (e.g., passw0rd123)
 # Export before run: export HMC_PASSWORD=<your_hmc_password>
 hmc_password: "{{ lookup('env', 'HMC_PASSWORD') }}"
-
 
 ####### Users #######
 
@@ -98,7 +97,6 @@ cc_owner_email: "cc_owner@email.com"
 # Export before run: export ACC_OWNER_DEFAULT_PASSWORD=<owner_default_password>
 cc_owner_default_password: "{{ lookup('env', 'ACC_OWNER_DEFAULT_PASSWORD') }}" # Specify default password for Owner's creation (e.g., "defaultP@ssw0rd")
 
-
 ####### Resources that are assigned to the appliance-owner #######
 
 ###########################################################################################
@@ -112,7 +110,7 @@ cc_owner_default_password: "{{ lookup('env', 'ACC_OWNER_DEFAULT_PASSWORD') }}" #
 # the owner_vars file will be drawn from the total resources specified in the resource package.
 # ------------------------------------------------------------------------------
 #
-# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR. 
+# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR.
 # For better performance, more resource can be assigned depending on the expected workload.
 #
 # Memory should always be a multiple of 1024 (1 GB).
@@ -132,7 +130,6 @@ package_gps: 6
 
 # Memory allocated for resource creation (in MB): depends on the CPC's customerStorageAvailable, it should be multiple of 1024.
 package_memory_mb: 51200
-
 
 ################################################################################
 # How to use this configuration file for Resource Package creation
@@ -167,7 +164,7 @@ prefix1: 23
 vlan1_id: 300
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk1_id: "0.0.5abc"
 
@@ -194,7 +191,6 @@ chpid1: "d0"
 # Port number for the lpar (0 or 1), if CHIP ID available then only port can be added
 zport1: 0
 
-
 ####### Second LPAR Configuration #######
 
 # Logical partition (LPAR) name for resource assignment (e.g., "BLUEC1") should be valid SSA lpar name
@@ -213,7 +209,7 @@ prefix2: 23
 vlan2_id: 300
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk2_id: "0.0.5abc"
 
@@ -222,11 +218,11 @@ is_fcp2: false
 
 # World Wide Port Name (WWPN) To be added only when is_fcp is true
 # Should be 16 digits
-wwpn1: "5000000000000001"
+wwpn2: "5000000000000001"
 
 # Logical Unit Number (LUN) To be added only when is_fcp is true
 # Should be 16 digits
-lun1: "7000000000000001"
+lun2: "7000000000000001"
 
 # Appliance IP address ( lpar ip)
 app_ip2: "9.x.x.x"

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/owner_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/owner_vars.yaml
@@ -10,7 +10,28 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
+
+###########################################################################################
+# Important Notes:  FAST ACTIVATE
+#
+# 1. Fast activate only works for LPARs that have been previously activated and then
+#    deactivated. ACC uses the preserved data from the last activation.
+#
+# 2. No image_id, cores, memory, processor_type, processor_usage, hostname, username,
+#    or password parameters are needed - these are all retrieved from preserved state.
+#
+# 3. The execution_action is automatically determined:
+#    - "default" for preserved (deactivated) LPARs
+#    - "appliance_only" for active LPARs in installer mode
+#
+# 4. The install parameter is always set to False for fast activate.
+#
+# 5. Set image_match_check to true (recommended) to ensure the preserved image matches
+#    the current image in the system, or false to skip validation.
+###########################################################################################
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
@@ -29,7 +50,6 @@ cc_admin_user: "{{ lookup('env', 'ACC_ADMIN_USER') }}"
 # Updated password for ACC admin) (e.g., "defaultPassw0rd1")
 # Export before run: export ACC_ADMIN_PASSWORD=<your_new_password>
 cc_admin_password: "{{ lookup('env', 'ACC_ADMIN_PASSWORD') }}"
-
 
 ####### Users (owner) #######
 
@@ -54,7 +74,6 @@ cc_owner_default_password: "{{ lookup('env', 'ACC_OWNER_DEFAULT_PASSWORD') }}"
 
 # Export before run: export ACC_OWNER_PASSWORD=<owner_new_password>
 cc_owner_password: "{{ lookup('env', 'ACC_OWNER_PASSWORD') }}"
-
 
 ####### Resources that are assigned to the appliance-owner #######
 
@@ -124,7 +143,6 @@ image_type: "image"
 # This is the fix type of image
 image_fix_type: "fix"
 
-
 ####### Image install #######
 
 # **********************************************************************************************
@@ -155,6 +173,13 @@ app_cores: 2
 # This value represents the memory assigned to each appliance LPAR.
 app_memory: 51200
 
+# image_match_check
+# Controls whether to verify that the preserved image matches the current image.
+# - true: Validates that the image used during previous activation matches the
+#         current image in the ACC. Recommended for safety.
+# - false: Skips image validation.
+# Default: true
+image_match_check: true
 
 ####### Appliance credential #######
 
@@ -168,7 +193,7 @@ app_memory: 51200
 # Secure Service Container graphical user interface (GUI). An administrator user ID can
 # be 1 - 32 characters long. It cannot contain blanks. Valid characters are numbers
 # 0 - 9, letters A - Z (upper or lower case), and the following special
-# characters: period (.), underscore (_), and hyphen (-). 
+# characters: period (.), underscore (_), and hyphen (-).
 # APP_PASSWORD: This is the Administrator password in the SSC user guide.
 # This password can have a minimum of 8 characters and a maximum of 256 characters.
 # An administrator password is case-sensitive and can contain numbers 0 - 9, letters A - Z
@@ -187,13 +212,11 @@ app_username: "{{ lookup('env', 'APP_USERNAME') }}"
 # Export before run: export APP_PASSWORD=<appliance_password>
 app_password: "{{ lookup('env', 'APP_PASSWORD') }}"
 
-
 ####### Available execution mode #######
 
 # . For default ACC (i.e, hmc_managed=true): "default", "prep_lpar_only", "appliance_only", "switch_to_installer"
 # . Standalone ACC (i.e, hmc_managed=false): "appliance_only", "switch_to_installer"
 execution_action: "default"
-
 
 ####################################################################################################################
 # In HMC, go to Customize Image Profile, navigate to the Processor section and check the processor type and value,
@@ -208,7 +231,7 @@ execution_action: "default"
 # otherwise set it to "general-purpose" for central processors
 # Set processor_type for the LPAR (used during image installation)
 # Keep in mind, the processor type defined here correlates to the min_ifl value defined earlier.
-#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance. 
+#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance.
 #     If min_ifls is set to 2 and processor_type is "general-purpose", then 2 gps will be assigned as the minimum for the appliance.
 processor_type: "general-purpose"
 

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/01_admin_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/01_admin_actions.yaml
@@ -12,6 +12,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-admin, for ACC-admin actions
@@ -126,6 +129,10 @@
     - name: Extract the admin token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 04 - Insert CPC information in ACC with dummy values (standalone mode)
       tags: admin

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/02a_assign_1_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/02a_assign_1_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-admin, for assigning one resource.
@@ -76,6 +79,10 @@
     - name: Extract the admin token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 01 - Validate WWPN and LUN values
       vars:
@@ -156,7 +163,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/02b_assign_2_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/02b_assign_2_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-admin, for assigning two resource.
@@ -77,6 +80,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 01 - Validate WWPN and LUN values
       vars:
         hex_pattern: "^[A-Fa-f0-9]{16}$"
@@ -105,7 +112,6 @@
             - item | length > 0
             - item is not match(hex_pattern)
           loop: "{{ lun_vars }}"
-
 
     - name: 02 - As ACC-admin, assign two LPARs to the owner
       block:
@@ -164,7 +170,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/03_owner_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/03_owner_actions.yaml
@@ -13,6 +13,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-owner, for ACC-owner actions
@@ -89,6 +92,11 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
 
     - name: 02 - Upload appliance image to the ACC as owner
       tags: owner

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/04_install_flow.yaml
@@ -14,6 +14,13 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Updated task ID extraction to support both 'task-id' and           |
+# *|     'task_id' formats for backward/forward compatibility               |
+# *|   - Added automatic rollback debug messages when activation fails.     |
+# *|   - Added support for fast activate mode                               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-owner, for ACC-owner actions
@@ -23,10 +30,48 @@
     - owner_vars.yaml
 
   pre_tasks:
+    - name: Prompt user to select activation mode
+      ansible.builtin.pause:
+        prompt: |
+
+          ╔════════════════════════════════════════════════════════════════╗
+          ║          ACC Appliance Activation Mode Selection               ║
+          ╚════════════════════════════════════════════════════════════════╝
+
+          Please select the activation mode:
+
+          1. INSTALL/ACTIVATE (Regular Mode)
+             - Install a new image or activate with new configuration
+             - Requires: image_id, cores, memory, processor settings,
+                        hostname, username, password
+             - Uses: /cluster/activate endpoint
+
+          2. FAST ACTIVATE (Quick Reactivation)
+             - Reactivate previously deactivated appliances
+             - Uses preserved configuration from last activation
+             - Requires: Only LPAR names and image_match_check boolean value(default = True)
+             - Uses: /cluster/inactive-appliance/fast-activate endpoint
+
+          Enter your choice (1 or 2)
+      register: mode_selection
+
+    - name: Set activation mode based on user input
+      ansible.builtin.set_fact:
+        use_fast_activate: "{{ mode_selection.user_input | trim == '2' }}"
+
+    - name: Display selected mode
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          ✅ Selected: FAST ACTIVATE mode
+          {% else %}
+          ✅ Selected: INSTALL/ACTIVATE mode
+          {% endif %}
+
     - name: Reminder - Export appliance-owner credentials
       ansible.builtin.pause:
         prompt: |
-          Before running this playbook, please export credentials:
+          Before continuing, please export credentials:
 
           export ACC_OWNER_PASSWORD=<owner_new_password>
           export APP_USERNAME=<appliance_username>
@@ -67,10 +112,29 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
+
+    - name: Display mode information
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          🚀 Running in FAST ACTIVATE mode
+          - Using preserved configuration from previous activation
+          - Endpoint: /cluster/inactive-appliance/fast-activate
+          {% else %}
+          📦 Running in INSTALL/ACTIVATE mode
+          - Using image_id: {{ image_id }}
+          - Endpoint: /cluster/activate
+          {% endif %}
+
     - name: Printing the image ID
       tags: owner, install
       ansible.builtin.debug:
         msg: "{{ image_id }}"
+      when: not use_fast_activate
 
     - name: 01 - Get list of running appliance
       ansible.builtin.uri:
@@ -107,7 +171,7 @@
           - "please ensure that you **export the same credentials** (username and password) for both."
           - "The LPAR should be in installer/appliance mode in HMC."
 
-    - name: 02 - Unlock quota using App id (comment this if already done)
+    - name: 02 - Unlock quota using App id
       tags: owner
       loop: "{{ app_ids }}"
       loop_control:
@@ -130,8 +194,9 @@
         timeout: 200
       register: unlock_responses
 
-    - name: 03 - As owner, install and activate the image
+    - name: 03 - As owner, install and activate the image (Regular Mode)
       tags: owner
+      when: not use_fast_activate
       ansible.builtin.uri:
         url: "{{ acc_url }}/cluster/activate"
         method: POST
@@ -169,6 +234,40 @@
         validate_certs: false
       register: activate_response
 
+    - name: 03 - As owner, fast activate the appliance from preserved state (Fast Activate Mode)
+      tags: owner, fast_activate
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/inactive-appliance/fast-activate"
+        method: POST
+        body: |
+          {
+            "{{ package_name }}":
+            {
+              "lpars": [
+                  {
+                    "name": "{{ lpar1_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  },
+                  {
+                    "name": "{{ lpar2_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  }
+                ]
+              }
+            }
+        body_format: json
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Content-Type: application/json
+        status_code: [200, 207]
+        validate_certs: false
+      when: use_fast_activate
+      register: fast_activate_response
+
+    - name: Set activate_response for unified processing
+      ansible.builtin.set_fact:
+        activate_response: "{{ fast_activate_response if use_fast_activate else activate_response }}"
+
     - name: Debug message for partial failure (207)
       tags: owner, install
       ansible.builtin.debug:
@@ -192,12 +291,17 @@
             activate_response.json
             | dict2items
             | map(attribute='value')
+            | select('mapping')
             | map('dict2items')
             | flatten
             | map(attribute='value')
-            | selectattr('task-id', 'defined')
-            | map(attribute='task-id')
+            | select('mapping')
+            | map('dict2items')
+            | flatten
+            | selectattr('key', 'in', ['task-id', 'task_id'])
+            | map(attribute='value')
             | list
+            | default([])
           }}
 
     - name: Print extracted task IDs
@@ -224,15 +328,15 @@
         headers:
           Authorization: "Bearer {{ access_token }}"
         validate_certs: false
-        return_content: yes
+        return_content: true
       loop: "{{ task_ids }}"
       loop_control:
         label: "Task {{ item }}"
       register: poll_status
-      retries: 45       # max retries
-      delay: 40         # wait between retries
+      retries: 45 # max retries
+      delay: 40 # wait between retries
       until: poll_status.json["action-status"] in ["Success", "Failed"]
-      failed_when: false 
+      failed_when: false
 
     - name: Evaluate all task results
       ansible.builtin.set_fact:
@@ -243,15 +347,48 @@
             | map(attribute='item')
             | list
           }}
+        acc_failed_lpars: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json.lpar')
+            | list
+          }}
+        acc_failed_task_details: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json')
+            | list
+          }}
+
+    - name: Debug message - Automatic rollback information
+      ansible.builtin.debug:
+        msg: |
+          ⚠️  {{ 'FAST ACTIVATE' if use_fast_activate else 'ACTIVATION' }} FAILED - AUTOMATIC ROLLBACK IN PROGRESS ⚠️
+
+          One or more activation tasks have failed.
+          Failed Task IDs: {{ acc_failed_tasks }}
+
+          NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
+    - name: "FAILED - Task Details"
+      ansible.builtin.debug:
+        var: acc_failed_task_details
+      when: acc_failed_tasks | length > 0
+
     - name: Fail play if any task failed
       ansible.builtin.fail:
-        msg: "❌ One or more ACC install tasks failed. Failed Task IDs: {{ acc_failed_tasks }}"
+        msg: >-
+          ❌ One or more ACC install tasks failed. Failed Task IDs:
+          {{ acc_failed_tasks }}. ACC has automatically rolled back
+          LPAR(s) {{ acc_failed_lpars | join(', ') }} to deactivate state.
       when: acc_failed_tasks | length > 0
-   
+
     - name: "Success message if both completed"
       ansible.builtin.debug:
         msg: "✅ Both tasks finished successfully or one succeeded and the other failed."
-
 
     - name: 05 - Get resources assigned to the owner by the admin
       tags: owner

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/README.md
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/README.md
@@ -14,6 +14,11 @@ These sample playbooks:
   communicate with the HMC.
 - MFA is disabled in ACC by the ACC-admin.
 
+### Features
+
+- **Execution Timestamp and ACC About Info Display**: All playbooks (`01_admin_actions.yaml`, `02a_assign_1_lpar.yaml`, `02b_assign_2_lpar.yaml`, `03_owner_actions.yaml`, `04_install_flow.yaml`) now display execution timestamp and ACC about information at the start of execution for better tracking and debugging.
+- **Fast Activate Support**: The `04_install_flow.yaml` playbook now supports fast activate mode for quick reactivation of previously deactivated appliances.
+
 ## Setting Up ACC - 01_admin_actions.yaml
 
 To set up the ACC, the following actions must be performed by the ACC-admin on
@@ -192,6 +197,26 @@ to bring these LPARs into the right state.
 Once the appliance-owner has performed the actions above, the appliance-owner can
 install the appliance. For that, perform the following actions as appliance-owner.
 
+### Activation Mode Selection
+
+The playbook now supports two activation modes:
+
+1. **INSTALL/ACTIVATE (Regular Mode)**:
+   - Install a new image or activate with new configuration
+   - Requires: image_id, cores, memory, processor settings, hostname, username, password
+   - Uses: `/cluster/activate` endpoint
+
+2. **FAST ACTIVATE (Quick Reactivation)**:
+   - Reactivate previously deactivated appliances
+   - Uses preserved configuration from last activation
+   - Requires: Only LPAR names and image_match_check boolean value (default = True)
+   - Uses: `/cluster/inactive-appliance/fast-activate` endpoint
+   - **Note**: For fast activate mode, only `ACC_OWNER_PASSWORD` is required. `APP_USERNAME` and `APP_PASSWORD` are not needed as the preserved configuration is used.
+
+When you run the playbook, you will be prompted to select the activation mode (1 or 2).
+
+### Installation Steps
+
 - In case the admin has only assigned a single LPAR using the
   `02a_assign_1_lpar.yaml` playbook, then remove the second LPAR's details in
   task `01 - As owner, install and activate the image` of `04_install_flow.yaml`.
@@ -208,15 +233,11 @@ install the appliance. For that, perform the following actions as appliance-owne
   ```
 
   Note that you will have to remove any trailing commas in the JSON object.
-- Export the newly set appliance-owner password in a terminal on your control node (laptop):
+
+- **For INSTALL/ACTIVATE mode**, export the newly set appliance-owner password and appliance credentials:
 
   ```bash
   export ACC_OWNER_PASSWORD=<owner_new_password>
-  ```
-
-- Export the username and password of the appliance LPAR(s):
-
-  ```bash
   export APP_USERNAME=<appliance_username>
   export APP_PASSWORD=<appliance_password>
   ```
@@ -225,7 +246,14 @@ install the appliance. For that, perform the following actions as appliance-owne
   that will be installed by ACC. These credentials are already set on the SSC LPAR
   by the HMC administrator, and these credentials are used by the playbook to
   communicate with the SSC LPAR.
-- `cd` to the directory `appliance_deploy_default_ansible`.
+
+- **For FAST ACTIVATE mode**, only export the appliance-owner password:
+
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_new_password>
+  ```
+
+- `cd` to the directory `appliance_deploy_standalone_ansible`.
 - Modify the variables in the file `owner_vars.yaml`.
   - You can install an appliance on the LPAR with 2 types of **execution action** in
     standalone mode:
@@ -234,6 +262,7 @@ install the appliance. For that, perform the following actions as appliance-owne
       variable to `true`.
     - `switch_to_installer`: When execution action is `switch_to_installer`, LPAR
       should already be activated in `SSC` mode. Moreover, you must remove the `install` parameter in the task `As owner, install and activate the image`.
+  - For fast activate mode, you can optionally set `image_match_check` variable (default is `true`).
 
 - Run the playbook:
 
@@ -241,7 +270,7 @@ install the appliance. For that, perform the following actions as appliance-owne
   ansible-playbook 04_install_flow.yaml
   ```
 
-The above playbook with send the install command to ACC. ACC will take up to
+The above playbook will send the install command to ACC. ACC will take up to
 20 mins to install the appliance. Check the status of the appliances on HMC and wait for the playbook to complete successfully.
 
 Note that to pull logs for appliances, concurrent updates for appliances, upgrade, health check

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/admin_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/admin_vars.yaml
@@ -10,6 +10,8 @@
 # *|   - Replaced acc_ip with acc_url and hmc_managed by acc_default_mode   |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
 
 #####################################################################################################
@@ -25,7 +27,6 @@
 #   - CHPID, Port  -> choose OSA
 #   - FID          -> choose NETH
 ######################################################################################################
-
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
@@ -99,7 +100,7 @@ z_machine_dpm_enabled: false
 # the owner_vars file will be drawn from the total resources specified in the resource package.
 # ------------------------------------------------------------------------------
 #
-# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR. 
+# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR.
 # For better performance, more resource can be assigned depending on the expected workload.
 #
 # Memory should always be a multiple of 1024 (1 GB).
@@ -153,7 +154,7 @@ prefix1: 23
 vlan1_id: 300
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk1_id: "0.0.5abc"
 
@@ -198,7 +199,7 @@ prefix2: 23
 vlan2_id: 30
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk2_id: "0.0.5abc"
 
@@ -207,11 +208,11 @@ is_fcp2: false
 
 # World Wide Port Name (WWPN) To be added only when is_fcp is true
 # Should be 16 digits
-wwpn1: "5000000000000001"
+wwpn2: "5000000000000001"
 
 # Logical Unit Number (LUN) To be added only when is_fcp is true
 # Should be 16 digits
-lun1: "7000000000000001"
+lun2: "7000000000000001"
 
 # Appliance IP address ( lpar ip)
 app2_ip: "9.x.x.x"

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/owner_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/owner_vars.yaml
@@ -10,7 +10,28 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
+
+###########################################################################################
+# Important Notes:  FAST ACTIVATE
+#
+# 1. Fast activate only works for LPARs that have been previously activated and then
+#    deactivated. ACC uses the preserved data from the last activation.
+#
+# 2. No image_id, cores, memory, processor_type, processor_usage, hostname, username,
+#    or password parameters are needed - these are all retrieved from preserved state.
+#
+# 3. The execution_action is automatically determined:
+#    - "default" for preserved (deactivated) LPARs
+#    - "appliance_only" for active LPARs in installer mode
+#
+# 4. The install parameter is always set to False for fast activate.
+#
+# 5. Set image_match_check to true (recommended) to ensure the preserved image matches
+#    the current image in the system, or false to skip validation.
+###########################################################################################
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
@@ -137,6 +158,14 @@ app_cores: 2
 # This value represents the memory assigned to each appliance LPAR.
 app_memory: 51200
 
+# image_match_check
+# Controls whether to verify that the preserved image matches the current image.
+# - true: Validates that the image used during previous activation matches the
+#         current image in the ACC. Recommended for safety.
+# - false: Skips image validation.
+# Default: true
+image_match_check: true
+
 ####### Appliance credential #######
 
 # Set Username for the appliance (used during appliance installation)
@@ -149,7 +178,7 @@ app_memory: 51200
 # Secure Service Container graphical user interface (GUI). An administrator user ID can
 # be 1 - 32 characters long. It cannot contain blanks. Valid characters are numbers
 # 0 - 9, letters A - Z (upper or lower case), and the following special
-# characters: period (.), underscore (_), and hyphen (-). 
+# characters: period (.), underscore (_), and hyphen (-).
 # APP_PASSWORD: This is the Administrator password in the SSC user guide.
 # This password can have a minimum of 8 characters and a maximum of 256 characters.
 # An administrator password is case-sensitive and can contain numbers 0 - 9, letters A - Z
@@ -198,7 +227,7 @@ execution_action: "appliance_only"
 # otherwise set it to "general-purpose" for central processors
 # Set processor_type for the LPAR (used during image installation)
 # Keep in mind, the processor type defined here correlates to the min_ifl value defined earlier.
-#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance. 
+#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance.
 #     If min_ifls is set to 2 and processor_type is "general-purpose", then 2 gps will be assigned as the minimum for the appliance.
 processor_type: "general-purpose"
 

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/01_admin_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/01_admin_actions.yaml
@@ -12,6 +12,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-admin, for ACC-admin actions
@@ -53,7 +56,7 @@
       prompt: "Do you want to initialize ACC? If you have already, then please type no. (yes/no)"
       private: false
       default: "yes"
-    
+
     - name: update_pass
       prompt: "Do you want to update the admin password? If you have already, then please type no (yes/no)"
       private: false
@@ -169,6 +172,10 @@
     - name: Extract the admin token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 04 - Insert CPC information in ACC with dummy values (standalone mode)
       tags: admin

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/02a_assign_1_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/02a_assign_1_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-admin, for assigning one resource.
@@ -83,6 +86,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 01 - Validate WWPN and LUN values
       vars:
         hex_pattern: "^[A-Fa-f0-9]{16}$"
@@ -109,7 +116,6 @@
             - item | length > 0
             - item is not match(hex_pattern)
           loop: "{{ lun_vars }}"
-
 
     - name: 02 - As ACC-admin, assign single LPAR to the owner
       block:
@@ -163,7 +169,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/02b_assign_2_lpar.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/02b_assign_2_lpar.yaml
@@ -13,6 +13,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-admin, for assigning two resource.
@@ -83,6 +86,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 01 - Validate WWPN and LUN values
       vars:
         hex_pattern: "^[A-Fa-f0-9]{16}$"
@@ -111,7 +118,6 @@
             - item | length > 0
             - item is not match(hex_pattern)
           loop: "{{ lun_vars }}"
-
 
     - name: 02 - As ACC-admin, assign two LPARs to the owner
       block:
@@ -170,7 +176,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/03_owner_actions.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/03_owner_actions.yaml
@@ -13,6 +13,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-owner, for ACC-owner actions
@@ -175,6 +178,10 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 04 - Upload appliance image to the ACC as owner
       tags: owner

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/04_install_flow.yaml
@@ -14,6 +14,13 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Updated task ID extraction to support both 'task-id' and           |
+# *|     'task_id' formats for backward/forward compatibility               |
+# *|   - Added automatic rollback debug messages when activation fails.     |
+# *|   - Added support for fast activate mode                               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Standalone playbook, run by ACC-owner, for ACC-owner actions
@@ -23,10 +30,48 @@
     - owner_vars.yaml
 
   pre_tasks:
+    - name: Prompt user to select activation mode
+      ansible.builtin.pause:
+        prompt: |
+
+          ╔════════════════════════════════════════════════════════════════╗
+          ║          ACC Appliance Activation Mode Selection               ║
+          ╚════════════════════════════════════════════════════════════════╝
+
+          Please select the activation mode:
+
+          1. INSTALL/ACTIVATE (Regular Mode)
+             - Install a new image or activate with new configuration
+             - Requires: image_id, cores, memory, processor settings,
+                        hostname, username, password
+             - Uses: /cluster/activate endpoint
+
+          2. FAST ACTIVATE (Quick Reactivation)
+             - Reactivate previously deactivated appliances
+             - Uses preserved configuration from last activation
+             - Requires: Only LPAR names and image_match_check boolean value(default = True)
+             - Uses: /cluster/inactive-appliance/fast-activate endpoint
+
+          Enter your choice (1 or 2)
+      register: mode_selection
+
+    - name: Set activation mode based on user input
+      ansible.builtin.set_fact:
+        use_fast_activate: "{{ mode_selection.user_input | trim == '2' }}"
+
+    - name: Display selected mode
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          ✅ Selected: FAST ACTIVATE mode
+          {% else %}
+          ✅ Selected: INSTALL/ACTIVATE mode
+          {% endif %}
+
     - name: Reminder - Export appliance-owner credentials
       ansible.builtin.pause:
         prompt: |
-          Before running this playbook, please export credentials:
+          Before continuing, please export credentials:
 
           export ACC_OWNER_PASSWORD=<owner_new_password>
           export APP_USERNAME=<appliance_username>
@@ -73,6 +118,23 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
+    - name: Display mode information
+      ansible.builtin.debug:
+        msg: |
+          {% if use_fast_activate %}
+          🚀 Running in FAST ACTIVATE mode
+          - Using preserved configuration from previous activation
+          - Endpoint: /cluster/inactive-appliance/fast-activate
+          {% else %}
+          📦 Running in INSTALL/ACTIVATE mode
+          - Using image_id: {{ image_id }}
+          - Endpoint: /cluster/activate
+          {% endif %}
+
     - name: 01 - Get list of running appliance
       ansible.builtin.uri:
         url: "{{ acc_url }}/resource/quotas"
@@ -108,7 +170,7 @@
           - "please ensure that you **export the same credentials** (username and password) for both."
           - "The LPAR should be in installer/appliance mode in HMC."
 
-    - name: 02 - Unlock quota using App id (comment this if already done)
+    - name: 02 - Unlock quota using App id
       tags: owner
       loop: "{{ app_ids }}"
       loop_control:
@@ -135,9 +197,11 @@
       tags: owner, install
       ansible.builtin.debug:
         msg: "{{ image_id }}"
+      when: not use_fast_activate
 
-    - name: 03 - As owner, install and activate the image
+    - name: 03 - As owner, install and activate the image (Regular Mode)
       tags: owner
+      when: not use_fast_activate
       ansible.builtin.uri:
         url: "{{ acc_url }}/cluster/activate"
         method: POST
@@ -175,6 +239,40 @@
         validate_certs: false
       register: activate_response
 
+    - name: 03 - As owner, fast activate the appliance from preserved state (Fast Activate Mode)
+      tags: owner, fast_activate
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/inactive-appliance/fast-activate"
+        method: POST
+        body: |
+          {
+            "{{ package_name }}":
+            {
+              "lpars": [
+                  {
+                    "name": "{{ lpar1_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  },
+                  {
+                    "name": "{{ lpar2_name }}",
+                    "image_match_check": {{ image_match_check | default(true) }}
+                  }
+                ]
+              }
+            }
+        body_format: json
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Content-Type: application/json
+        status_code: [200, 207]
+        validate_certs: false
+      when: use_fast_activate
+      register: fast_activate_response
+
+    - name: Set activate_response for unified processing
+      ansible.builtin.set_fact:
+        activate_response: "{{ fast_activate_response if use_fast_activate else activate_response }}"
+
     - name: Debug message for partial failure (207)
       tags: owner, install
       ansible.builtin.debug:
@@ -198,12 +296,17 @@
             activate_response.json
             | dict2items
             | map(attribute='value')
+            | select('mapping')
             | map('dict2items')
             | flatten
             | map(attribute='value')
-            | selectattr('task-id', 'defined')
-            | map(attribute='task-id')
+            | select('mapping')
+            | map('dict2items')
+            | flatten
+            | selectattr('key', 'in', ['task-id', 'task_id'])
+            | map(attribute='value')
             | list
+            | default([])
           }}
 
     - name: Print extracted task IDs
@@ -230,15 +333,15 @@
         headers:
           Authorization: "Bearer {{ access_token }}"
         validate_certs: false
-        return_content: yes
+        return_content: true
       loop: "{{ task_ids }}"
       loop_control:
         label: "Task {{ item }}"
       register: poll_status
-      retries: 45       # max retries
-      delay: 40         # wait between retries
+      retries: 45 # max retries
+      delay: 40 # wait between retries
       until: poll_status.json["action-status"] in ["Success", "Failed"]
-      failed_when: false 
+      failed_when: false
 
     - name: Evaluate all task results
       ansible.builtin.set_fact:
@@ -249,15 +352,48 @@
             | map(attribute='item')
             | list
           }}
+        acc_failed_lpars: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json.lpar')
+            | list
+          }}
+        acc_failed_task_details: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json')
+            | list
+          }}
+
+    - name: Debug message - Automatic rollback information
+      ansible.builtin.debug:
+        msg: |
+          ⚠️  {{ 'FAST ACTIVATE' if use_fast_activate else 'ACTIVATION' }} FAILED - AUTOMATIC ROLLBACK IN PROGRESS ⚠️
+
+          One or more activation tasks have failed.
+          Failed Task IDs: {{ acc_failed_tasks }}
+
+          NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
+    - name: "FAILED - Task Details"
+      ansible.builtin.debug:
+        var: acc_failed_task_details
+      when: acc_failed_tasks | length > 0
+
     - name: Fail play if any task failed
       ansible.builtin.fail:
-        msg: "❌ One or more ACC install tasks failed. Failed Task IDs: {{ acc_failed_tasks }}"
+        msg: >-
+          ❌ One or more ACC install tasks failed. Failed Task IDs:
+          {{ acc_failed_tasks }}. ACC has automatically rolled back
+          LPAR(s) {{ acc_failed_lpars | join(', ') }} to deactivate state.
       when: acc_failed_tasks | length > 0
-   
+
     - name: "Success message if both completed"
       ansible.builtin.debug:
         msg: "✅ Both tasks finished successfully or one succeeded and the other failed."
-
 
     - name: 05 - Get resources assigned to the owner by the admin
       tags: owner

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/README.md
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/README.md
@@ -16,6 +16,11 @@ These sample playbooks:
 - In these playbooks, the MFA enablement done during the
   initialization of ACC.
 
+### Features
+
+- **Execution Timestamp and ACC About Info Display**: All playbooks (`01_admin_actions.yaml`, `02a_assign_1_lpar.yaml`, `02b_assign_2_lpar.yaml`, `03_owner_actions.yaml`, `04_install_flow.yaml`) now display execution timestamp and ACC about information at the start of execution for better tracking and debugging.
+- **Fast Activate Support**: The `04_install_flow.yaml` playbook now supports fast activate mode for quick reactivation of previously deactivated appliances.
+
 ## Setting Up ACC - 01_admin_actions.yaml
 
 To set up the ACC, the following actions must be performed by the ACC-admin on
@@ -223,6 +228,26 @@ Note: To generate the access token for the owner, provide the OTP when prompted 
 Use the last saved mfa_secret of owner to generate this OTP through your authenticator app.
 When the command prompt requests an OTP, enter the OTP generated using the saved mfa_secret.
 
+### Activation Mode Selection
+
+The playbook now supports two activation modes:
+
+1. **INSTALL/ACTIVATE (Regular Mode)**:
+   - Install a new image or activate with new configuration
+   - Requires: image_id, cores, memory, processor settings, hostname, username, password
+   - Uses: `/cluster/activate` endpoint
+
+2. **FAST ACTIVATE (Quick Reactivation)**:
+   - Reactivate previously deactivated appliances
+   - Uses preserved configuration from last activation
+   - Requires: Only LPAR names and image_match_check boolean value (default = True)
+   - Uses: `/cluster/inactive-appliance/fast-activate` endpoint
+   - **Note**: For fast activate mode, only `ACC_OWNER_PASSWORD` is required. `APP_USERNAME` and `APP_PASSWORD` are not needed as the preserved configuration is used.
+
+When you run the playbook, you will be prompted to select the activation mode (1 or 2).
+
+### Installation Steps
+
 - In case the admin has only assigned a single LPAR using the
   `02a_assign_1_lpar.yaml` playbook, then remove the second LPAR's details in
   task `01 - As owner, install and activate the image` of `04_install_flow.yaml`.
@@ -239,15 +264,11 @@ When the command prompt requests an OTP, enter the OTP generated using the saved
   ```
 
   Note that you will have to remove any trailing commas in the JSON object.
-- Export the newly set appliance-owner password in a terminal on your control node (laptop):
+
+- **For INSTALL/ACTIVATE mode**, export the newly set appliance-owner password and appliance credentials:
 
   ```bash
   export ACC_OWNER_PASSWORD=<owner_new_password>
-  ```
-
-- Export the username and password of the appliance LPAR(s):
-
-  ```bash
   export APP_USERNAME=<appliance_username>
   export APP_PASSWORD=<appliance_password>
   ```
@@ -256,7 +277,14 @@ When the command prompt requests an OTP, enter the OTP generated using the saved
   that will be installed by ACC. These credentials are already set on the SSC LPAR
   by the HMC administrator, and these credentials are used by the playbook to
   communicate with the SSC LPAR.
-- `cd` to the directory `appliance_deploy_default_ansible`.
+
+- **For FAST ACTIVATE mode**, only export the appliance-owner password:
+
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_new_password>
+  ```
+
+- `cd` to the directory `appliance_deploy_standalone_mfa_ansible`.
 - Modify the variables in the file `owner_vars.yaml`.
   - You can install an appliance on the LPAR with 2 types of **execution action** in
     standalone mode:
@@ -265,6 +293,7 @@ When the command prompt requests an OTP, enter the OTP generated using the saved
       variable to `true`.
     - `switch_to_installer`: When execution action is `switch_to_installer`, LPAR
       should already be activated in `SSC` mode. Moreover, you must remove the `install` parameter in the task `As owner, install and activate the image`.
+  - For fast activate mode, you can optionally set `image_match_check` variable (default is `true`).
 
 - Run the playbook:
 
@@ -272,7 +301,7 @@ When the command prompt requests an OTP, enter the OTP generated using the saved
   ansible-playbook 04_install_flow.yaml
   ```
 
-The above playbook with send the install command to ACC. ACC will take up to
+The above playbook will send the install command to ACC. ACC will take up to
 20 mins to install the appliance. Check the status of the appliances on HMC and wait for the playbook to complete successfully.
 
 Note that to pull logs for appliances, concurrent updates for appliances, upgrade, health check

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/admin_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/admin_vars.yaml
@@ -10,6 +10,8 @@
 # *|   - Replaced acc_ip with acc_url and hmc_managed by acc_default_mode   |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
 
 #####################################################################################################
@@ -25,8 +27,6 @@
 #   - CHPID, Port  -> choose OSA
 #   - FID          -> choose NETH
 ######################################################################################################
-
-
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
@@ -108,7 +108,7 @@ z_machine_dpm_enabled: false
 # the owner_vars file will be drawn from the total resources specified in the resource package.
 # ------------------------------------------------------------------------------
 #
-# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR. 
+# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR.
 # For better performance, more resource can be assigned depending on the expected workload.
 #
 # Memory should always be a multiple of 1024 (1 GB).
@@ -162,7 +162,7 @@ prefix1: 23
 vlan1_id: 300
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk1_id: "0.0.5abc"
 
@@ -207,7 +207,7 @@ prefix2: 23
 vlan2_id: 300
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk2_id: "0.0.5abc"
 
@@ -216,11 +216,11 @@ is_fcp2: false
 
 # World Wide Port Name (WWPN) To be added only when is_fcp is true
 # Should be 16 digits
-wwpn1: "5000000000000001"
+wwpn2: "5000000000000001"
 
 # Logical Unit Number (LUN) To be added only when is_fcp is true
 # Should be 16 digits
-lun1: "7000000000000001"
+lun2: "7000000000000001"
 
 # Appliance IP address ( lpar ip)
 app_ip2: "9.x.x.x"

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/owner_vars.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/owner_vars.yaml
@@ -10,7 +10,28 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
+
+###########################################################################################
+# Important Notes:  FAST ACTIVATE
+#
+# 1. Fast activate only works for LPARs that have been previously activated and then
+#    deactivated. ACC uses the preserved data from the last activation.
+#
+# 2. No image_id, cores, memory, processor_type, processor_usage, hostname, username,
+#    or password parameters are needed - these are all retrieved from preserved state.
+#
+# 3. The execution_action is automatically determined:
+#    - "default" for preserved (deactivated) LPARs
+#    - "appliance_only" for active LPARs in installer mode
+#
+# 4. The install parameter is always set to False for fast activate.
+#
+# 5. Set image_match_check to true (recommended) to ensure the preserved image matches
+#    the current image in the system, or false to skip validation.
+###########################################################################################
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
@@ -152,6 +173,14 @@ app_cores: 2
 # This value represents the memory assigned to each appliance LPAR.
 app_memory: 51200
 
+# image_match_check
+# Controls whether to verify that the preserved image matches the current image.
+# - true: Validates that the image used during previous activation matches the
+#         current image in the ACC. Recommended for safety.
+# - false: Skips image validation.
+# Default: true
+image_match_check: true
+
 ####### Appliance credential #######
 
 # Set Username for the appliance (used during appliance installation)
@@ -164,7 +193,7 @@ app_memory: 51200
 # Secure Service Container graphical user interface (GUI). An administrator user ID can
 # be 1 - 32 characters long. It cannot contain blanks. Valid characters are numbers
 # 0 - 9, letters A - Z (upper or lower case), and the following special
-# characters: period (.), underscore (_), and hyphen (-). 
+# characters: period (.), underscore (_), and hyphen (-).
 # APP_PASSWORD: This is the Administrator password in the SSC user guide.
 # This password can have a minimum of 8 characters and a maximum of 256 characters.
 # An administrator password is case-sensitive and can contain numbers 0 - 9, letters A - Z
@@ -213,7 +242,7 @@ execution_action: "appliance_only"
 # otherwise set it to "general-purpose" for central processors
 # Set processor_type for the LPAR (used during image installation)
 # Keep in mind, the processor type defined here correlates to the min_ifl value defined earlier.
-#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance. 
+#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance.
 #     If min_ifls is set to 2 and processor_type is "general-purpose", then 2 gps will be assigned as the minimum for the appliance.
 processor_type: "general-purpose"
 

--- a/z_appliance_control_center/other_usecases_ansible/00_resource_scan.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/00_resource_scan.yaml
@@ -11,6 +11,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run as appliance-owner, to scan the resources
@@ -74,6 +77,10 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
 
     - name: 04 - Get resources assigned to the owner by the admin
       tags: owner

--- a/z_appliance_control_center/other_usecases_ansible/01_upgrade_flow.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/01_upgrade_flow.yaml
@@ -12,6 +12,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by appliance-owner, for appliance upgrade
@@ -83,24 +86,67 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
+
     - name: 04 - Upload upgrade appliance image to the ACC as owner
       tags: owner
       # The uri module cannot upload binary files.
       # One can use `src`, but both `src` and `body` can't be used together.
-      ansible.builtin.shell: 'curl -k -X "POST" \
+      ansible.builtin.shell: 'curl -v -k -X "POST" \
         "{{ acc_url }}/images" \
         -H "Authorization: Bearer {{ access_token }}" \
         -H "Content-Type: multipart/form-data" \
         -F "data=@{{ image_path }}" \
-        -F "image_name=awesome-img-2" -F "image_version=v1.0" -F "description=This image is an awesome image..." \
         -F "image_type={{ image_type }}" \
         -F "min_ifls={{ min_ifls }}" -F "min_memory={{ min_memory }}"'
-      register: response
+      register: upload_response
       changed_when: false
-      failed_when: >
-        response.rc != 0 or
-        (response.stdout is defined and 'exception' in response.stdout | lower)
+      failed_when: false
       # noqa command-instead-of-module command-instead-of-shell
+
+    - name: 04a - Display upload status
+      ansible.builtin.debug:
+        msg: "Image upload {{ 'successful' if upload_response.rc == 0 else 'failed with return code: ' + (upload_response.rc | string) }}"
+
+    - name: 04b - Check if image upload failed due to duplicate name
+      ansible.builtin.set_fact:
+        image_exists: "{{ ('Image name already exists' in upload_response.stdout) or ('E00402' in upload_response.stdout) }}"
+
+    - name: 04c - Display warning that the image upload failed due to a duplicate image already in ACC.
+      when: image_exists
+      ansible.builtin.debug:
+        msg:
+          - "⚠️  WARNING: Image with this name and version already exists for current user"
+          - ""
+          - "You can either:"
+          - "  1. Continue with an existing image (recommended)"
+          - "  2. Delete the existing image and re-run this playbook"
+
+    - name: 04d - Prompt user to continue with existing image
+      when: image_exists
+      ansible.builtin.pause:
+        prompt: |
+
+          Do you want to continue with an existing image? (yes/no)
+          Answering 'no' will stop the playbook.
+      register: continue_with_existing
+
+    - name: 04e - Fail if user chooses not to continue
+      when: image_exists and (continue_with_existing.user_input | lower != 'yes')
+      ansible.builtin.fail:
+        msg: "Playbook stopped by user. Please delete the existing image or change the image name in the playbook."
+
+    - name: 04f - Check for other upload errors
+      when: not image_exists and (upload_response.rc != 0 or 'exception' in upload_response.stdout | lower)
+      ansible.builtin.fail:
+        msg: "Image upload failed: {{ upload_response.stdout }}"
+
+    - name: 04g - Parse uploaded image ID from response
+      when: not image_exists
+      ansible.builtin.set_fact:
+        uploaded_image_id: "{{ (upload_response.stdout | from_json).image_id }}"
 
     - name: 05 - Get image information
       tags: owner, install
@@ -111,51 +157,93 @@
           Authorization: "Bearer {{ access_token }}"
           Content-Type: application/json
         validate_certs: false
-      register: response
-      failed_when: response.json.images | length == 0
+      register: get_images_response
+      failed_when: get_images_response.json.images | length == 0
 
-    - name: Printing the response of get image
-      tags: owner, install
+    - name: 05a - Display all available images
+      when: image_exists
       ansible.builtin.debug:
-        msg: "{{ response.json }}"
+        msg: "{{ get_images_response.json | to_nice_json }}"
 
-    - name: Extract the image ID from the DB
+    - name: 05b - Display available images header
+      when: image_exists
+      ansible.builtin.debug:
+        msg: "📋 Available Images:"
+
+    - name: 05c - Display each image for selection
+      when: image_exists
+      ansible.builtin.debug:
+        msg:
+          - "ID: {{ item.id }}"
+          - "Name: {{ item.name }}"
+          - "Version: {{ item.version | default('N/A') }}"
+          - "Type: {{ item.image_type | default('N/A') }}"
+          - "Description: {{ item.description | default('N/A') }}"
+      loop: "{{ get_images_response.json.images }}"
+      loop_control:
+        label: "Image ID: {{ item.id }}"
+
+    - name: 05d - Prompt user to select image ID
+      when: image_exists
+      ansible.builtin.pause:
+        prompt: |
+
+          Please enter the Image ID from the list above that you want to use for the upgrade:
+      register: selected_image_id_input
+
+    - name: 05e - Validate selected image ID exists
+      when: image_exists
+      ansible.builtin.set_fact:
+        selected_image_id: "{{ selected_image_id_input.user_input | int }}"
+        valid_image_ids: "{{ get_images_response.json.images | map(attribute='id') | list }}"
+
+    - name: 05f - Fail if selected image ID is invalid
+      when: image_exists and (selected_image_id | int not in valid_image_ids)
+      ansible.builtin.fail:
+        msg: "Invalid image ID '{{ selected_image_id }}'. Please run the playbook again and select a valid ID from the list."
+
+    - name: 06 - Set the image ID to use for upgrade
       tags: owner, install
       ansible.builtin.set_fact:
-        image_id: "{{ response.json.images[-1].id }}"
+        image_id: "{{ selected_image_id if image_exists else uploaded_image_id }}"
 
-    - name: Printing the image ID
+    - name: 07 - Printing the image ID
       tags: owner, install
       ansible.builtin.debug:
         msg: "{{ image_id }}"
 
-    - name: 06 - As owner, upgrade the image using image
+    - name: 08 - As owner, upgrade the image using image
       tags: owner, install
-      ansible.builtin.uri:
-        url: "{{ acc_url }}/cluster/upgrade"
-        method: POST
-        body: |
-          {
-            "{{ package_name }}": {
-            "lpars": ["{{ lpar_name }}"],
-            "image_id": {{ image_id | int }}
-            }
-          }
-        body_format: json
-        headers:
-          Authorization: "Bearer {{ access_token }}"
-          Content-Type: application/json
-        validate_certs: false
-        status_code: [200, 207]
-        dest: "{{ upgrade_appliance_data }}"
+      ansible.builtin.shell: |
+        http_code=$(curl -sS -k \
+          -D "{{ upgrade_appliance_data }}.headers" \
+          -o "{{ upgrade_appliance_data }}" \
+          -w "%{http_code}" \
+          -X POST "{{ acc_url }}/cluster/upgrade" \
+          -H "Authorization: Bearer {{ access_token }}" \
+          -H "Content-Type: application/json" \
+          --data '{"{{ package_name }}":{"lpars":["{{ lpar_name }}"],"image_id":{{ image_id | int }}}}')
+        printf '%s\n' "$http_code"
       changed_when: false
       register: upgrade_response
+      # noqa command-instead-of-module command-instead-of-shell
+
+    - name: Fail when upgrade request returns bad request (400)
+      tags: owner, install
+      ansible.builtin.fail:
+        msg: |
+          Upgrade request failed with HTTP 400.
+          Response ZIP saved at: {{ upgrade_appliance_data }}
+          Response headers saved at: {{ upgrade_appliance_data }}.headers
+
+          Inspect the ZIP contents to see the ACC validation error.
+      when: upgrade_response.stdout | trim == '400'
 
     - name: Debug message for partial failure (207)
       tags: owner, install
       ansible.builtin.debug:
         msg: "WARNING: Status code 207 received - one or more LPARs failed to perform the task"
-      when: upgrade_response.status == 207
+      when: upgrade_response.stdout | trim == '207'
 
     - name: Wait for 15 seconds
       ansible.builtin.pause:

--- a/z_appliance_control_center/other_usecases_ansible/02_sync_cpc_lpars.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/02_sync_cpc_lpars.yaml
@@ -14,6 +14,9 @@
 # *|   - Increased the timeout to 180 seconds                               |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 - name: ACC playbook, to be run as an ACC-admin, for syncing ACC with the HMC.
   hosts: localhost
@@ -31,52 +34,6 @@
       ansible.builtin.debug:
         msg: "{{ acc_url }}"
 
-    - name: Get Initialize status
-      ansible.builtin.uri:
-        url: "{{ acc_url }}/init"
-        method: GET
-        return_content: true
-        validate_certs: false
-      register: get_init_response
-
-    - name: Print init response
-      ansible.builtin.debug:
-        var: get_init_response.json
-
-    - name: Set ACC mode fact
-      ansible.builtin.set_fact:
-        acc_mode: "{{ get_init_response.json.mode }}"
-
-    - name: Print detected ACC mode
-      ansible.builtin.debug:
-        msg: "ACC is running in '{{ acc_mode }}' mode."
-
-    - name: Reminder - Export HMC credentials
-      when: acc_mode == "default"
-      ansible.builtin.pause:
-        prompt: |
-          Before running this playbook, please export HMC credentials:
-
-          export HMC_USER=<enter_HMC_username>
-          export HMC_PASSWORD=<enter_HMC_password>
-
-          Press Ctrl+C now to cancel if you haven't done this.
-          The playbook will continue shortly.
-        seconds: 5
-
-    - name: Check required environment variables
-      vars:
-        required_env_vars:
-          - HMC_USER
-          - HMC_PASSWORD
-
-      ansible.builtin.fail:
-        msg: "Missing required environment variable: {{ item }}"
-      when:
-        - acc_mode == "default"
-        - lookup('env', item) == ""
-      loop: "{{ required_env_vars }}"
-
   vars_prompt:
     - name: cc_admin_user
       prompt: "Enter ACC-admin's username"
@@ -87,11 +44,10 @@
       private: true
 
   tasks:
-
     - name: 00 - Check MFA is enabled or not
       ansible.legacy.pause:
         prompt: "Do you have MFA enabled? (yes/no)"
-        echo: yes
+        echo: true
       register: mfa_enabled_input
 
     - name: 01 - Set MFA enabled
@@ -102,7 +58,7 @@
       when: mfa_enabled
       ansible.legacy.pause:
         prompt: "Enter MFA OTP generated for admin:"
-      register: mfa_otp_input
+      register: mfa_admin_otp_input
 
     - name: 03 - Get authentication token from the ACC as admin
       tags: admin
@@ -122,6 +78,67 @@
       tags: admin
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: 03a - Get Initialize status
+      tags: admin
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/init"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+        return_content: true
+        validate_certs: false
+      register: get_init_response
+
+    - name: Print init response
+      tags: admin
+      ansible.builtin.debug:
+        var: get_init_response.json
+
+    - name: Set ACC mode fact
+      tags: admin
+      ansible.builtin.set_fact:
+        acc_mode: "{{ get_init_response.json.mode }}"
+
+    - name: Print detected ACC mode
+      tags: admin
+      ansible.builtin.debug:
+        msg: "ACC is running in '{{ acc_mode }}' mode."
+
+    - name: Reminder - Export HMC credentials
+      tags: admin
+      when: acc_mode == "default"
+      ansible.builtin.pause:
+        prompt: |
+          ACC is running in DEFAULT mode.
+          Before continuing, please export HMC credentials:
+
+          export HMC_USER=<enter_HMC_username>
+          export HMC_PASSWORD=<enter_HMC_password>
+
+          Press Ctrl+C now to cancel if you haven't done this.
+          The playbook will continue shortly.
+        seconds: 5
+
+    - name: Check required environment variables for default mode
+      tags: admin
+      vars:
+        required_env_vars:
+          - HMC_USER
+          - HMC_PASSWORD
+      ansible.builtin.fail:
+        msg: "Missing required environment variable: {{ item }}"
+      when:
+        - acc_mode == "default"
+        - lookup('env', item) == ""
+      loop: "{{ required_env_vars }}"
+
+    - name: Display ACC about information
+      ansible.builtin.debug:
+        var: about_response.json
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
 
     - name: 04 - Set HMC configuration in the ACC
       tags: admin

--- a/z_appliance_control_center/other_usecases_ansible/03_pull_ssc_logs.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/03_pull_ssc_logs.yaml
@@ -10,11 +10,15 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Renamed the output file name                                       |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Refactored to include reusable tasks in 17_tasks_pull_ssc_logs.yaml|
 # *+------------------------------------------------------------------------+
 
-- name: ACC playbook, to get logs from appliances, decryptable only by IBM
+- name: ACC playbook, to get logs from appliances
   hosts: localhost
-  gather_facts: false
+  gather_facts: true
   vars_prompt:
     - name: "ssc_ip"
       prompt: "Enter your SSC LPAR's IP"
@@ -30,90 +34,17 @@
       private: false
 
   vars:
-    api_base_url: "https://{{ ssc_ip }}/api/com.ibm.zaci.system"
+    log_destination: "/tmp/ssc_{{ '%Y-%m-%d_%H:%M:%S' | strftime }}.gz"
 
   tasks:
-    - name: 00 - Get authentication token from the SSC LPAR
-      ansible.builtin.uri:
-        url: "{{ api_base_url }}/api-tokens"
-        method: POST
-        headers:
-          Accept: "application/vnd.ibm.zaci.payload+json"
-          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
-          zACI-API: "com.ibm.zaci.system/1.0"
-        body:
-          kind: "request"
-          parameters:
-            user: "{{ lpar_username }}"
-            password: "{{ lpar_password }}"
-        validate_certs: false
-        return_content: true
-        body_format: json
-      register: auth_response
+    - name: Display playbook execution information
+      ansible.builtin.include_tasks:
+        file: common_display_execution_info.yaml
 
-    - name: Extract the token
-      ansible.builtin.set_fact:
-        access_token: "{{ auth_response.json.parameters.token }}"
+    - name: Include SSC log pulling tasks
+      ansible.builtin.include_tasks:
+        file: 17_tasks_pull_ssc_logs.yaml
 
-    - name: 01 - Send an alert to SSC to create logs
-      ansible.builtin.uri:
-        url: "{{ api_base_url }}/alerts"
-        method: POST
-        headers:
-          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
-          Accept: "application/vnd.ibm.zaci.payload+json;version=1.0"
-          Authorization: "Bearer {{ access_token }}"
-          zACI-API: "com.ibm.zaci.system/1.0"
-        body:
-          kind: "request"
-          parameters:
-            reason: "Testing alerts because of: {{ reason }}"
-            diag_info: "concurrent"
-        validate_certs: false
-        return_content: true
-        body_format: json
-        status_code: 202
-      register: alert_response
-
-    - name: Extract the alert UUID
-      ansible.builtin.set_fact:
-        alert_uuid: "{{ alert_response.json.parameters.self | regex_search('[0-9a-fA-F-]{36}') }}"
-
-    - name: Display extracted UUID
+    - name: Display log download location
       ansible.builtin.debug:
-        var: alert_uuid
-
-    - name: 02 - Wait till alert is handled by SSC
-      ansible.builtin.uri:
-        url: "{{ api_base_url }}/alerts/{{ alert_uuid }}"
-        method: GET
-        headers:
-          Accept: "application/vnd.ibm.zaci.payload+json;version=1.0"
-          Authorization: "Bearer {{ access_token }}"
-          zACI-API: "com.ibm.zaci.system/1.0"
-        validate_certs: false
-        return_content: false
-        body_format: json
-        status_code: 200
-      register: alert_info
-      until: alert_info.status == 200
-      retries: 60
-      delay: 10
-      failed_when: alert_info.status not in [200, 202]
-
-    - name: Display information about the alert
-      ansible.builtin.debug:
-        var: alert_info.json
-
-    - name: 03 - Download diagnostic info as binary log at /tmp/ssc_<date>_<time>.gz
-      ansible.builtin.uri:
-        url: "{{ api_base_url }}/alerts/{{ alert_uuid }}/diag-info"
-        method: GET
-        headers:
-          Authorization: "Bearer {{ access_token }}"
-          zACI-API: "com.ibm.zaci.system/1.0"
-          Accept: "application/octet-stream"
-        validate_certs: false
-        status_code: 200
-        timeout: 180
-        dest: "/tmp/ssc_{{ '%Y-%m-%d_%H:%M:%S' | strftime }}.gz" # destination file format eg: /tmp/ssc_2026-03-06_02:30:49.gz
+        msg: "SSC logs downloaded successfully at location: {{ log_destination }}"

--- a/z_appliance_control_center/other_usecases_ansible/04_managed_appliance_update.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/04_managed_appliance_update.yaml
@@ -12,6 +12,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by appliance-owner, for appliance upgrade
@@ -27,8 +30,6 @@
           Before running this playbook, please export appliance-owner credentials:
 
           export ACC_OWNER_PASSWORD=<owner_password>
-          export APP_USERNAME=<appliance_username>
-          export APP_PASSWORD=<appliance_password>
 
           Press Ctrl+C now to cancel if you haven't done this.
           The playbook will continue shortly.
@@ -38,8 +39,6 @@
       vars:
         required_env_vars:
           - ACC_OWNER_PASSWORD
-          - APP_USERNAME
-          - APP_PASSWORD
 
       ansible.builtin.fail:
         msg: "Missing required environment variable: {{ item }}"
@@ -87,23 +86,87 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
+
     - name: 04 - Upload fix image/update bundle to the ACC as owner
       tags: owner
       # The uri module cannot upload binary files.
       # One can use `src`, but both `src` and `body` can't be used together.
-      ansible.builtin.shell: 'curl -k -X "POST" \
+      ansible.builtin.shell: 'curl -v -k -X "POST" \
         "{{ acc_url }}/images" \
         -H "Authorization: Bearer {{ access_token }}" \
         -H "Content-Type: multipart/form-data" \
         -F "data=@{{ update_bundle_path }}" \
         -F "image_type={{ image_fix_type }}" \
         -F "min_ifls={{ min_ifls }}" -F "min_memory={{ min_memory }}"'
-      register: response
+      register: upload_response
       changed_when: false
-      failed_when: >
-        response.rc != 0 or
-        (response.stdout is defined and 'exception' in response.stdout | lower)
+      failed_when: false
       # noqa command-instead-of-module command-instead-of-shell
+
+    - name: 04a - Display upload status
+      ansible.builtin.debug:
+        msg: "Image upload {{ 'successful' if upload_response.rc == 0 else 'failed with return code: ' + (upload_response.rc | string) }}"
+
+    - name: 04b - Check upload result type
+      ansible.builtin.set_fact:
+        upload_is_html: "{{ '<!doctype html>' in upload_response.stdout | lower or '<html' in upload_response.stdout | lower }}"
+        upload_has_exception: "{{ 'exception' in upload_response.stdout | lower }}"
+        upload_is_duplicate: "{{ ('Image name already exists' in upload_response.stdout) or ('E00402' in upload_response.stdout) }}"
+
+    - name: 04c - Fail on HTML error response (Bad Request, etc.)
+      when: upload_is_html
+      ansible.builtin.fail:
+        msg: |
+          Image upload failed with HTTP error.
+
+          Response: {{ upload_response.stdout }}
+
+          Common causes:
+          - Invalid request format
+          - Missing or incorrect parameters
+          - Authentication issues
+          - Check the curl command and API endpoint
+
+    - name: 04d - Check if image upload failed due to duplicate name
+      ansible.builtin.set_fact:
+        image_exists: "{{ upload_is_duplicate }}"
+
+    - name: 04e - Display warning that the image upload failed due to a duplicate image already in ACC.
+      when: image_exists
+      ansible.builtin.debug:
+        msg:
+          - "⚠️  WARNING: Image with this name and version already exists for current user"
+          - ""
+          - "You can either:"
+          - "  1. Continue with an existing image (recommended)"
+          - "  2. Delete the existing image and re-run this playbook"
+
+    - name: 04f - Prompt user to continue with existing image
+      when: image_exists
+      ansible.builtin.pause:
+        prompt: |
+
+          Do you want to continue with an existing image? (yes/no)
+          Answering 'no' will stop the playbook.
+      register: continue_with_existing
+
+    - name: 04g - Fail if user chooses not to continue
+      when: image_exists and (continue_with_existing.user_input | lower != 'yes')
+      ansible.builtin.fail:
+        msg: "Playbook stopped by user. Please delete the existing image or change the image name in the playbook."
+
+    - name: 04h - Check for other upload errors (JSON exceptions)
+      when: not image_exists and not upload_is_html and (upload_response.rc != 0 or upload_has_exception)
+      ansible.builtin.fail:
+        msg: "Image upload failed: {{ upload_response.stdout }}"
+
+    - name: 04i - Parse uploaded image ID from response
+      when: not image_exists and not upload_is_html
+      ansible.builtin.set_fact:
+        uploaded_image_id: "{{ (upload_response.stdout | from_json).image_id }}"
 
     - name: 05 - Get update bundle information
       tags: owner, install
@@ -114,25 +177,63 @@
           Authorization: "Bearer {{ access_token }}"
           Content-Type: application/json
         validate_certs: false
-      register: response
-      failed_when: response.json.images | length == 0
+      register: get_images_response
+      failed_when: get_images_response.json.images | length == 0
 
-    - name: Printing the response of get update bundle
-      tags: owner, install
+    - name: 05a - Display all available images
+      when: image_exists
       ansible.builtin.debug:
-        msg: "{{ response.json }}"
+        msg: "{{ get_images_response.json | to_nice_json }}"
 
-    - name: Extract the update bundle ID from the DB
+    - name: 05b - Display available images header
+      when: image_exists
+      ansible.builtin.debug:
+        msg: "📋 Available Images:"
+
+    - name: 05c - Display each image for selection
+      when: image_exists
+      ansible.builtin.debug:
+        msg:
+          - "---"
+          - "ID: {{ item.id }}"
+          - "Name: {{ item.name }}"
+          - "Version: {{ item.version | default('N/A') }}"
+          - "Type: {{ item.image_type | default('N/A') }}"
+          - "Description: {{ item.description | default('N/A') }}"
+      loop: "{{ get_images_response.json.images }}"
+      loop_control:
+        label: "Image ID: {{ item.id }}"
+
+    - name: 05d - Prompt user to select image ID
+      when: image_exists
+      ansible.builtin.pause:
+        prompt: |
+
+          Please enter the Image ID from the list above that you want to use for the upgrade:
+      register: selected_image_id_input
+
+    - name: 05e - Validate selected image ID exists
+      when: image_exists
+      ansible.builtin.set_fact:
+        selected_image_id: "{{ selected_image_id_input.user_input | int }}"
+        valid_image_ids: "{{ get_images_response.json.images | map(attribute='id') | list }}"
+
+    - name: 05f - Fail if selected image ID is invalid
+      when: image_exists and (selected_image_id | int not in valid_image_ids)
+      ansible.builtin.fail:
+        msg: "Invalid image ID '{{ selected_image_id }}'. Please run the playbook again and select a valid ID from the list."
+
+    - name: 06 - Set the image ID to use for upgrade
       tags: owner, install
       ansible.builtin.set_fact:
-        image_id: "{{ response.json.images[-1].id }}"
+        image_id: "{{ selected_image_id if image_exists else uploaded_image_id }}"
 
-    - name: Printing the update bundle ID
+    - name: 07 - Printing the update bundle ID
       tags: owner, install
       ansible.builtin.debug:
         msg: "image id: {{ image_id }}"
 
-    - name: 06 - Get list of running appliance
+    - name: 08 - Get list of running appliance
       ansible.builtin.uri:
         url: "{{ acc_url }}/resource/quotas"
         method: GET
@@ -142,72 +243,60 @@
         validate_certs: false
       register: quotas_response
 
-    - name: Print quotas response
-      ansible.builtin.debug:
-        var: quotas_response.json
+    - name: Fail if no appliances found
+      ansible.builtin.fail:
+        msg: "No appliances found in resource quotas for this owner."
+      when: quotas_response.json | length == 0
 
-    - name: Extract app IDs from quotas
-      ansible.builtin.set_fact:
-        app_ids: >-
-          {{
-            quotas_response.json
-            | selectattr('id', 'defined')
-            | map(attribute='id')
-            | list
-          }}
-    - name: Print extracted app IDs
+    - name: Print available appliances summary
       ansible.builtin.debug:
-        msg: "App IDs to unlock: {{ app_ids | join(', ') }}"
+        msg: >
+          {% for app in quotas_response.json %}
+            ID: {{ app.id }},
+            Name: {{ app.name }},
+            IP: {{ app.interfaces[0].ip | default('N/A') }},
+            Status: {{ 'Locked' if app.is_locked else 'Unlocked' }}
+          {% endfor %}
 
-    - name: 07 - Unlock quota using App id (comment this if already done)
-      tags: owner
-      loop: "{{ app_ids }}"
+    - name: 09 - Unlock appliances one by one
+      ansible.builtin.include_tasks: 11_unlock_each_appliance.yaml
+      loop: "{{ quotas_response.json }}"
       loop_control:
-        loop_var: app_id
-      ansible.builtin.uri:
-        url: "{{ acc_url }}/unlock_quota"
-        method: POST
-        body:
-          {
-            "ssc_username": "{{ app_username }}",
-            "ssc_password": "{{ app_password }}",
-            "app_id": "{{ app_id }}",
-          }
-        body_format: json
-        headers:
-          Authorization: "Bearer {{ access_token }}"
-          Content-Type: application/json
-        status_code: 200
-        timeout: 200
-        validate_certs: false
-      register: unlock_responses
+        loop_var: appliance
 
-    - name: 08 - As owner, concurrent update the image using image_id {{ image_id }}
+    - name: 10 - As owner, concurrent update the image using image_id {{ image_id }}
       tags: owner, install
-      ansible.builtin.uri:
-        url: "{{ acc_url }}/cluster/upgrade"
-        method: POST
-        body: |
-          {
-            "{{ package_name }}": {
-              "lpars": ["{{ lpar_name }}"],
-              "image_id": {{ image_id | int }}
-            }
-          }
-        body_format: json
-        headers:
-          Authorization: "Bearer {{ access_token }}"
-          Content-Type: application/json
-        validate_certs: false
-        status_code: [200, 207]
-        dest: "{{ upgrade_fix_data }}"
+      ansible.builtin.shell:
+        cmd: |
+          http_code=$(curl -sS -k \
+            -D "{{ upgrade_fix_data }}.headers" \
+            -o "{{ upgrade_fix_data }}" \
+            -w "%{http_code}" \
+            -X POST "{{ acc_url }}/cluster/upgrade" \
+            -H "Authorization: Bearer {{ access_token }}" \
+            -H "Content-Type: application/json" \
+            --data '{"{{ package_name }}":{"lpars":["{{ lpar_name }}"],"image_id":{{ image_id | int }}}}')
+          printf '%s\n' "$http_code"
+      changed_when: false
       register: upgrade_response
+      # noqa command-instead-of-module command-instead-of-shell
+
+    - name: Fail when concurrent update request returns bad request (400)
+      tags: owner, install
+      ansible.builtin.fail:
+        msg: |
+          Concurrent update request failed with HTTP 400.
+          Response ZIP saved at: {{ upgrade_fix_data }}
+          Response headers saved at: {{ upgrade_fix_data }}.headers
+
+          Inspect the ZIP contents to see the ACC validation error.
+      when: upgrade_response.stdout | trim == '400'
 
     - name: Debug message for partial failure (207)
       tags: owner, install
       ansible.builtin.debug:
         msg: "WARNING: Status code 207 received - one or more LPARs failed to perform the task"
-      when: upgrade_response.status == 207
+      when: upgrade_response.stdout | trim == '207'
 
     - name: Wait for 15 seconds
       ansible.builtin.pause:

--- a/z_appliance_control_center/other_usecases_ansible/05_managed_appliance_health_and_pull_logs.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/05_managed_appliance_health_and_pull_logs.yaml
@@ -12,6 +12,9 @@
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by appliance-owner, for Health Check and Pull SSA logs
@@ -82,6 +85,10 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
 
     - name: 01 - Health Monitoring of SSA
       tags: owner, install

--- a/z_appliance_control_center/other_usecases_ansible/06_acc_appliance_update.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/06_acc_appliance_update.yaml
@@ -10,6 +10,9 @@
 # *|   - Added mandatory wait before checking if appliance rebooted         |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by appliance-owner, for ACC appliance update
@@ -40,7 +43,123 @@
   vars:
     appliance_url: "https://{{ ssc_ip }}/api/com.ibm.zaci.system"
   tasks:
-    - name: 00 - Get authentication token from the ACC as appliance-owner
+    - name: 00 - Validate update bundle file format
+      block:
+        - name: Check if update bundle file exists
+          ansible.builtin.stat:
+            path: "{{ update_bundle_path }}"
+          register: bundle_file_stat
+
+        - name: Fail if bundle file does not exist
+          ansible.builtin.fail:
+            msg: |
+              ❌ Update bundle file not found: {{ update_bundle_path }}
+
+              Please verify:
+              - The file path is correct
+              - You have read permissions for the file
+          when: not bundle_file_stat.stat.exists
+
+        - name: Check file type and content
+          ansible.builtin.shell: |
+            file "{{ update_bundle_path }}"
+          register: file_type_check
+          failed_when: false
+          changed_when: false
+
+        - name: Check if file is PGP/GPG encrypted (valid update bundle)
+          ansible.builtin.shell: |
+            set -o pipefail
+            file "{{ update_bundle_path }}" | grep -iE "(PGP|GPG).*encrypted"
+          args:
+            executable: /bin/bash
+          register: pgp_check
+          failed_when: false
+          changed_when: false
+
+        - name: Check if file contains image indicators
+          ansible.builtin.shell: |
+            set -o pipefail
+            file "{{ update_bundle_path }}" | grep -iE "(acc_image|\.img|image\.img)"
+          register: image_check
+          failed_when: false
+          changed_when: false
+
+        - name: Fail if file is an image file (not update bundle)
+          ansible.builtin.fail:
+            msg: |
+              ❌ INVALID FILE: This is an ACC image file, not an update bundle!
+
+              File: {{ update_bundle_path | basename }}
+              Type: {{ file_type_check.stdout }}
+
+              ⚠️  CRITICAL ERROR: You provided an ACC appliance IMAGE file.
+              This playbook requires a PGP-encrypted UPDATE BUNDLE, not an image.
+
+              What you provided:
+              - File contains: acc_image.img (this is a disk image)
+              - Format: Gzip compressed disk image
+              - Purpose: For fresh ACC installation, not updates
+
+              What this playbook needs:
+              - PGP RSA encrypted TAR archive
+              - File name pattern: update_bundle_*.tar or update-bundle-*.tar
+              - Contains: Encrypted update packages and metadata
+
+              Example of CORRECT file:
+              ✅ /path/to/update_bundle_1.2.13.tar
+
+              Example of WRONG file (what you provided):
+              ❌ {{ update_bundle_path | basename }}
+
+              Solution:
+              1. Obtain the correct UPDATE BUNDLE (not image) from your build system
+              2. Update bundles are PGP encrypted TAR files
+              3. For image-based deployment, use a different playbook
+
+              The playbook will now exit to save your time.
+          when: image_check.rc == 0
+
+        - name: Fail if file is not PGP/GPG encrypted
+          ansible.builtin.fail:
+            msg: |
+              ❌ INVALID UPDATE BUNDLE: File is not PGP/GPG encrypted!
+
+              File: {{ update_bundle_path | basename }}
+              Type: {{ file_type_check.stdout }}
+
+              ⚠️  ACC update bundles MUST be PGP/GPG RSA encrypted.
+
+              Expected file signature:
+              - "PGP RSA encrypted session key" or "GPG encrypted data"
+              - Encrypted TAR archive
+
+              Your file signature:
+              - {{ file_type_check.stdout }}
+
+              Common issues:
+              1. Using unencrypted TAR files
+              2. Using image files (.img, .img.gz)
+              3. Using wrong file from build artifacts
+              4. File corruption during download
+
+              Solution:
+              - Obtain a properly PGP/GPG-encrypted update bundle
+              - Verify file with: file <bundle_path>
+              - Should show: "PGP RSA encrypted session key" or "GPG encrypted data"
+
+              The playbook will now exit.
+          when: pgp_check.rc != 0
+
+        - name: Display bundle validation success
+          ansible.builtin.debug:
+            msg: |
+              ✅ Update bundle validation passed
+              File: {{ update_bundle_path }}
+              Size: {{ (bundle_file_stat.stat.size / 1024 / 1024) | round(2) }} MB
+              Type: {{ file_type_check.stdout }}
+
+    - name: 01 - Get authentication token from the ACC as appliance-owner
       ansible.builtin.uri:
         url: "{{ appliance_url }}/api-tokens"
         method: POST

--- a/z_appliance_control_center/other_usecases_ansible/07_insert_hmc_creds.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/07_insert_hmc_creds.yaml
@@ -13,6 +13,10 @@
 # *|   - Replaced hmc_url with hmc_ip                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Added optional HMC credential expiry support                       |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by ACC-admin, for inserting HMC credentials
@@ -22,6 +26,10 @@
     - admin_vars.yaml
 
   pre_tasks:
+    - name: Prepare ACC URL
+      ansible.builtin.set_fact:
+        acc_url: "https://{{ acc_ip }}:{{ acc_port }}/api"
+
     - name: Reminder - Export credentials
       ansible.builtin.pause:
         prompt: |
@@ -54,6 +62,11 @@
       prompt: "Enter ACC-admin's Password"
       private: true
 
+    - name: days_to_clear_hmc_creds
+      prompt: "Enter HMC credential expiry in days (1-14, or leave empty to skip)"
+      private: false
+      default: ""
+
   tasks:
     - name: 00 - Check MFA is enabled or not
       ansible.builtin.pause:
@@ -70,7 +83,14 @@
         prompt: "Enter MFA OTP generated for admin:"
       register: mfa_otp_input
 
-    - name: 03 - Get authentication token from the ACC as admin
+    - name: 03 - Validate expiry days if provided
+      ansible.builtin.fail:
+        msg: "Invalid value for days_to_clear_hmc_creds. Enter an integer from 1 to 14, or leave empty to skip."
+      when:
+        - days_to_clear_hmc_creds != ""
+        - (days_to_clear_hmc_creds is not match('^[0-9]+$') or days_to_clear_hmc_creds | int < 1 or days_to_clear_hmc_creds | int > 14)
+
+    - name: 04 - Get authentication token from the ACC as admin
       ansible.builtin.uri:
         url: "https://{{ acc_ip }}:{{ acc_port }}/api/user/token"
         body:
@@ -83,11 +103,15 @@
         validate_certs: false
       register: auth_response
 
-    - name: Extract the admin token
+    - name: 05 - Extract the admin token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
-    - name: 04 - Set HMC configuration in the ACC (can take up to 10 mins)
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
+
+    - name: 06 - Set HMC configuration in the ACC (can take up to 10 mins)
       ansible.builtin.uri:
         url: "https://{{ acc_ip }}:{{ acc_port }}/api/config/hmcconfig"
         timeout: 600
@@ -97,6 +121,7 @@
           userid: "{{ hmc_user }}"
           password: "{{ hmc_password }}"
           verify_cert: false
+          days_to_clear_hmc_creds: "{{ (days_to_clear_hmc_creds | int) if days_to_clear_hmc_creds != '' else omit }}"
         body_format: json
         headers:
           Authorization: "Bearer {{ access_token }}"
@@ -105,7 +130,37 @@
         status_code: 204
       register: response
 
-    - name: 05 - As a validation, get list of CPCs attached to the HMC
+    - name: 07 - Get HMC configuration from ACC
+      ansible.builtin.uri:
+        url: "https://{{ acc_ip }}:{{ acc_port }}/api/config/hmcconfig"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Content-Type: application/json
+        validate_certs: false
+        return_content: true
+      register: hmc_config_response
+
+    - name: 07a - Print HMC configuration
+      ansible.builtin.debug:
+        msg: "{{ hmc_config_response.json }}"
+
+    - name: 08 - Check HMC credential expiry using about API
+      ansible.builtin.uri:
+        url: "https://{{ acc_ip }}:{{ acc_port }}/api/about"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Content-Type: application/json
+        validate_certs: false
+        return_content: true
+      register: about_response
+
+    - name: 08a - Print about API response
+      ansible.builtin.debug:
+        msg: "{{ about_response.json }}"
+
+    - name: 09 - As a validation, get list of CPCs attached to the HMC
       ansible.builtin.uri:
         url: "https://{{ acc_ip }}:{{ acc_port }}/api/cpcs"
         method: GET
@@ -115,6 +170,6 @@
         validate_certs: false
       register: response
 
-    - name: Printing the available CPCs
+    - name: 10 - Printing the available CPCs
       ansible.builtin.debug:
         msg: "{{ response.json }}"

--- a/z_appliance_control_center/other_usecases_ansible/08_restart_acc.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/08_restart_acc.yaml
@@ -10,19 +10,34 @@
 # *|   - Tested with ACC 1.2.12                                             |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook to reboot SSC appliance (ACC)
   hosts: localhost
   gather_facts: true
+  vars_files:
+    - admin_vars.yaml
 
   vars_prompt:
     - name: "ssc_ip"
       prompt: "Enter SSC LPAR's (ACC) IP"
       private: false
+
+    - name: cc_admin_user
+      prompt: "Enter ACC-admin's username"
+      private: false
+
+    - name: cc_admin_password
+      prompt: "Enter ACC-admin's password"
+      private: true
+
     - name: "lpar_username"
       prompt: "Enter SSC LPAR's (ACC) username"
       private: false
+
     - name: "lpar_password"
       prompt: "Enter SSC LPAR's (ACC) password"
       private: true
@@ -30,8 +45,79 @@
   vars:
     api_base_url: "https://{{ ssc_ip }}/api/com.ibm.zaci.system"
 
+  pre_tasks:
+    - name: Prepare ACC URL
+      tags: admin
+      ansible.builtin.set_fact:
+        acc_url: "https://{{ ssc_ip }}:{{ acc_port }}/api"
+
+    - name: Printing the ACC url
+      tags: admin
+      ansible.builtin.debug:
+        msg: "{{ acc_url }}"
+
   tasks:
-    - name: 00 - Get authentication token from the SSC LPAR
+    - name: 00 - Check MFA is enabled or not
+      ansible.legacy.pause:
+        prompt: "Do you have MFA enabled? (yes/no)"
+        echo: true
+      register: mfa_enabled_input
+
+    - name: 01 - Set MFA enabled
+      ansible.legacy.set_fact:
+        mfa_enabled: "{{ mfa_enabled_input.user_input | lower == 'yes' }}"
+
+    - name: 02 - Prompt for OTP if MFA is enabled
+      when: mfa_enabled
+      ansible.legacy.pause:
+        prompt: "Enter MFA OTP generated for admin:"
+      register: mfa_admin_otp_input
+
+    - name: 03 - Get authentication token from the ACC as admin
+      tags: admin
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/user/token"
+        body:
+          username: "{{ cc_admin_user }}"
+          password: "{{ cc_admin_password }}"
+          otp: "{{ (mfa_admin_otp_input.user_input if mfa_enabled else omit) }}"
+        body_format: json
+        method: POST
+        return_content: true
+        validate_certs: false
+      register: auth_response
+
+    - name: Extract the admin token
+      tags: admin
+      ansible.builtin.set_fact:
+        admin_access_token: "{{ auth_response.json.access_token }}"
+
+    - name: 04 - Check for in-progress tasks in ACC
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/tasks?status=Inprogress"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ admin_access_token }}"
+          Accept: "application/json"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+      register: tasks_response
+      failed_when: false
+
+    - name: Display in-progress tasks if any exist
+      when: tasks_response.json | length > 0
+      ansible.builtin.debug:
+        msg: "{{ tasks_response.json }}"
+
+    - name: Fail if tasks are in progress
+      when: tasks_response.json | length > 0
+      ansible.builtin.fail:
+        msg: |
+          ⚠️ WARNING: Tasks are currently in progress in ACC
+          ACC restart cannot be performed while tasks are in progress. Please wait for the in progress tasks to complete before restarting ACC.
+
+    - name: 05 - Get authentication token from the SSC LPAR
       ansible.builtin.uri:
         url: "{{ api_base_url }}/api-tokens"
         method: POST
@@ -52,6 +138,10 @@
     - name: Extract the token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.parameters.token }}"
+
+    - name: Display playbook execution information
+      ansible.builtin.include_tasks:
+        file: common_display_execution_info.yaml
 
     - name: 01 - Reboot the SSC appliance
       ansible.builtin.uri:

--- a/z_appliance_control_center/other_usecases_ansible/09_get_disruptive_dumps.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/09_get_disruptive_dumps.yaml
@@ -6,10 +6,13 @@
 # *| [12.12.2025]                                                             |
 # *|   - Tested with ACC 1.2.10                                               |
 # *|   - Renamed 11_get_disruptive_dumps.yaml to 09_get_disruptive_dumps.yaml |
-# *| [02.13.2026]                                                           |
-# *|   - Tested with ACC 1.2.12                                             |
-# *| [04.02.2026]                                                           |
-# *|   - Tested with ACC 1.2.13                                             |
+# *| [02.13.2026]                                                             |
+# *|   - Tested with ACC 1.2.12                                               |
+# *| [04.02.2026]                                                             |
+# *|   - Tested with ACC 1.2.13                                               |
+# *| [06.26.2026]                                                             |
+# *|   - Tested with ACC 1.2.14                                               |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+--------------------------------------------------------------------------+
 
 - name: ACC Playbook - Trigger disruptive dump and collect logs from appliance
@@ -66,6 +69,10 @@
     - name: Extract the token
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.parameters.token }}"
+
+    - name: Display playbook execution information
+      ansible.builtin.include_tasks:
+        file: common_display_execution_info.yaml
 
     - name: 01 - Trigger disruptive dump
       ansible.builtin.uri:

--- a/z_appliance_control_center/other_usecases_ansible/10_unlock_appliances.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/10_unlock_appliances.yaml
@@ -12,6 +12,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Playbook, run by appliance-owner, for appliance-owner actions
@@ -76,6 +79,10 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
 
     - name: 04 - Get list of running appliance
       ansible.builtin.uri:

--- a/z_appliance_control_center/other_usecases_ansible/11_unlock_each_appliance.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/11_unlock_each_appliance.yaml
@@ -8,12 +8,14 @@
 # *|   - Renamed 13_unlock_each_appliances.yaml to 11_unlock_eachappliance.yaml |
 # *| [02.13.2026]                                                               |
 # *|   - Tested with ACC 1.2.12                                                 |
-# *| [04.02.2026]                                                           |
-# *|   - Tested with ACC 1.2.13                                             |
+# *| [04.02.2026]                                                               |
+# *|   - Tested with ACC 1.2.13                                                 |
+# *| [06.26.2026]                                                               |
+# *|   - Tested with ACC 1.2.14                                                 |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+----------------------------------------------------------------------------+
 
-
-# This playbook is not meant to be executed directly. It is automatically called 
+# This playbook is not meant to be executed directly. It is automatically called
 # by the other_usecases_ansible/12_unlock_appliances.yaml.
 # and ssa_deploy_ansible/04_unlock_ssa_after_hmc_install.yaml playbooks when run as
 # the appliance owner.

--- a/z_appliance_control_center/other_usecases_ansible/13_restart_appliances.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/13_restart_appliances.yaml
@@ -8,6 +8,9 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run by appliance-owner, for restarting an appliance.
@@ -74,6 +77,10 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
 
     - name: 04 - Get list of running appliance
       ansible.builtin.uri:

--- a/z_appliance_control_center/other_usecases_ansible/14_acc_export_config.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/14_acc_export_config.yaml
@@ -1,0 +1,124 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2025                                             |
+# *| ACC Configuration Export Playbook                                      |
+# *| [04.02.2026]                                                           |
+# *|   - Tested with ACC 1.2.13                                             |
+# *|   - Added network configuration for ACC LPAR                           |
+# *|   - Added IFLs/GPs configuration for ACC LPAR                          |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *+------------------------------------------------------------------------+
+
+- name: Export ACC appliance configuration
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - export_import_vars.yaml
+
+  vars_prompt:
+    - name: ssc_ip
+      prompt: "Enter your SSC LPAR's (ACC) IP"
+      private: false
+
+    - name: app_username
+      prompt: "Enter your SSC LPAR's (ACC) username"
+      private: false
+
+    - name: app_password
+      prompt: "Enter your SSC LPAR's (ACC) password"
+      private: true
+
+  vars:
+    appliance_url: "https://{{ ssc_ip }}/api/com.ibm.zaci.system"
+
+  tasks:
+    - name: Get authentication token from ACC
+      ansible.builtin.uri:
+        url: "{{ appliance_url }}/api-tokens"
+        method: POST
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+        body:
+          kind: "request"
+          parameters:
+            user: "{{ app_username }}"
+            password: "{{ app_password }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+      register: auth_response
+
+    - name: Set access token
+      ansible.builtin.set_fact:
+        access_token: "{{ auth_response.json.parameters.token }}"
+
+    - name: Display playbook execution information
+      ansible.builtin.include_tasks:
+        file: common_display_execution_info.yaml
+
+    - name: Ensure export directory exists
+      ansible.builtin.file:
+        path: "{{ export_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Generate timestamp
+      ansible.builtin.set_fact:
+        export_timestamp: "{{ ansible_date_time.iso8601_basic }}"
+
+    - name: Build export filename
+      ansible.builtin.set_fact:
+        export_file: "{{ lpar_name }}_ACC_config_{{ export_timestamp }}.data"
+
+    - name: Display important disclaimer before export
+      ansible.legacy.pause:
+        prompt: |
+
+          ⚠️  IMPORTANT DISCLAIMER:
+          Images uploaded to ACC are not retained as part of the config export and should be re-uploaded
+          after configuration restore.
+
+          Press ENTER to continue with the export or Ctrl+C to abort...
+
+    - name: Export appliance configuration using curl
+      ansible.builtin.shell: |
+        curl -k -X POST \
+          "{{ appliance_url }}/appliance-configuration/export" \
+          -H "zACI-API: com.ibm.zaci.system/1.0" \
+          -H "Accept: application/octet-stream" \
+          -H "Content-Type: application/vnd.ibm.zaci.payload+json;version=1.0" \
+          -H "Authorization: Bearer {{ access_token }}" \
+          -d '{"kind":"request","parameters":{"description":"ACC configuration export"}}' \
+          --output "{{ export_dir }}/{{ export_file }}" \
+          --max-time 1200 \
+          --connect-timeout 30
+      register: export_result
+      changed_when: false
+      failed_when: false
+      ignore_errors: true
+      # noqa command-instead-of-module command-instead-of-shell
+
+    - name: Verify export file was created and has content
+      ansible.builtin.stat:
+        path: "{{ export_dir }}/{{ export_file }}"
+      register: export_file_stat
+
+    - name: Check if export was successful
+      ansible.legacy.fail:
+        msg: "Export failed - file was not created or is empty"
+      when: not export_file_stat.stat.exists or export_file_stat.stat.size == 0
+
+    - name: Display export file size
+      ansible.builtin.debug:
+        msg: "Export completed successfully. File size: {{ (export_file_stat.stat.size / 1024 / 1024) | round(2) }} MB"
+
+    - name: Show export file location
+      ansible.builtin.debug:
+        msg:
+          - "Configuration exported to {{ export_dir }}/{{ export_file }}"
+          - ""
+          - "IMPORTANT: Please save this file to a secure location."
+          - "You will need this file to revert back ACC in case of failures or to restore configuration."

--- a/z_appliance_control_center/other_usecases_ansible/15_acc_restore_config.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/15_acc_restore_config.yaml
@@ -1,0 +1,256 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2025                                             |
+# *| ACC Configuration Restore Playbook                                     |
+# *| Includes post-import reboot & operational checks                       |
+# *| [04.02.2026]                                                           |
+# *|   - Tested with ACC 1.2.13                                             |
+# *|   - Added network configuration for ACC LPAR                           |
+# *|   - Added IFLs/GPs configuration for ACC LPAR                          |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *+------------------------------------------------------------------------+
+
+- name: Restore ACC appliance configuration
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - export_import_vars.yaml
+
+  vars_prompt:
+    - name: ssc_ip
+      prompt: "Enter your SSC LPAR's (ACC) IP"
+      private: false
+
+    - name: app_username
+      prompt: "Enter your SSC LPAR's (ACC) username"
+      private: false
+
+    - name: app_password
+      prompt: "Enter your SSC LPAR's (ACC) password"
+      private: true
+
+    - name: import_file
+      prompt: "Enter full path of the exported configuration file"
+      private: false
+
+  vars:
+    appliance_url: "https://{{ ssc_ip }}/api/com.ibm.zaci.system"
+
+  tasks:
+    # ---------------------------------------------------------------------
+    # Validate input file
+    # ---------------------------------------------------------------------
+    - name: Verify import file exists
+      ansible.builtin.stat:
+        path: "{{ import_file }}"
+      register: import_file_stat
+
+    - name: Fail if file does not exist
+      ansible.legacy.fail:
+        msg: "Configuration file not found: {{ import_file }}"
+      when: not import_file_stat.stat.exists
+
+    # ---------------------------------------------------------------------
+    # Authentication
+    # ---------------------------------------------------------------------
+    - name: Get authentication token from ACC
+      ansible.builtin.uri:
+        url: "{{ appliance_url }}/api-tokens"
+        method: POST
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+        body:
+          kind: "request"
+          parameters:
+            user: "{{ app_username }}"
+            password: "{{ app_password }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+      register: auth_response
+
+    - name: Set access token
+      ansible.builtin.set_fact:
+        access_token: "{{ auth_response.json.parameters.token }}"
+
+    - name: Display playbook execution information
+      ansible.builtin.include_tasks:
+        file: common_display_execution_info.yaml
+
+    # ---------------------------------------------------------------------
+    # Display import file information
+    # ---------------------------------------------------------------------
+    - name: Display import file information
+      ansible.builtin.debug:
+        msg:
+          - "Import file: {{ import_file }}"
+          - "Filename: {{ import_file | basename }}"
+
+    - name: Read import file header to extract metadata
+      ansible.builtin.command:
+        cmd: head -n 3 "{{ import_file }}"
+      register: import_file_header
+      changed_when: false
+
+    - name: Extract and parse JSON metadata from import file
+      ansible.builtin.set_fact:
+        import_metadata: "{{ (import_file_header.stdout_lines[1] | regex_search(\"Comment: '(.+)'$\", '\\1'))[0] | from_json }}"
+
+    - name: Display import file metadata
+      ansible.builtin.debug:
+        msg:
+          - "=== Import File Metadata ==="
+          - "Comment: {{ import_metadata.comment }}"
+          - "Date: {{ import_metadata.date }}"
+          - "Message Type: {{ import_metadata.message_type }}"
+          - "============================"
+
+    - name: Display important disclaimer before import
+      ansible.legacy.pause:
+        prompt: |
+
+          ⚠️  IMPORTANT DISCLAIMER:
+          Images uploaded to ACC are not retained as part of the config export and should be re-uploaded
+          after configuration restore.
+
+          Press ENTER to continue with the import or Ctrl+C to abort...
+
+    - name: Pause before importing configuration
+      ansible.legacy.pause:
+        seconds: 10
+        prompt: "Pausing for 10 seconds before importing configuration..."
+
+    # ---------------------------------------------------------------------
+    # Import configuration (binary upload)
+    # ---------------------------------------------------------------------
+    - name: Import appliance configuration
+      ansible.builtin.uri:
+        url: "{{ appliance_url }}/appliance-configuration/import?apply_now=true"
+        method: POST
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/octet-stream"
+          Authorization: "Bearer {{ access_token }}"
+        body_format: raw
+        src: "{{ import_file }}"
+        status_code: [200, 202, 204]
+        validate_certs: false
+        timeout: 1200
+      register: import_response
+
+    - name: Show import response
+      ansible.builtin.debug:
+        var: import_response
+
+    # ---------------------------------------------------------------------
+    # Post-import reboot / operational checks
+    # ---------------------------------------------------------------------
+    - name: Short wait to allow appliance restart to begin
+      ansible.legacy.pause:
+        seconds: 5
+
+    - name: Wait until appliance becomes operational after import
+      ansible.builtin.uri:
+        url: "{{ appliance_url }}/appliance/is-operational"
+        method: GET
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+          Authorization: "Bearer {{ access_token }}"
+        return_content: false
+        validate_certs: false
+      register: is_operational_response
+      failed_when: is_operational_response.status not in [-1, 204]
+      retries: 30
+      delay: 10
+      until: is_operational_response.status == 204
+
+    - name: Confirm appliance is operational
+      ansible.builtin.debug:
+        msg: "ACC appliance is operational after configuration restore"
+
+    # ---------------------------------------------------------------------
+    # Re-authenticate after restart
+    # ---------------------------------------------------------------------
+    - name: Re-authenticate after appliance restart
+      ansible.builtin.uri:
+        url: "{{ appliance_url }}/api-tokens"
+        method: POST
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+        body:
+          kind: "request"
+          parameters:
+            user: "{{ app_username }}"
+            password: "{{ app_password }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+      register: post_reboot_auth
+
+    - name: Update access token after reboot
+      ansible.builtin.set_fact:
+        access_token: "{{ post_reboot_auth.json.parameters.token }}"
+
+    # ---------------------------------------------------------------------
+    # Post-process appliance update
+    # ---------------------------------------------------------------------
+    # This upgrade workflow requires ACC 1.2.10 and above
+    - name: Trigger post-process appliance update
+      ansible.builtin.uri:
+        url: "{{ appliance_url }}/appliance-update/post-process"
+        method: POST
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+          Authorization: "Bearer {{ access_token }}"
+        return_content: true
+        validate_certs: false
+        status_code: [200, 202]
+      register: post_process_trigger_response
+
+    - name: Show post-process trigger response
+      ansible.builtin.debug:
+        var: post_process_trigger_response
+
+    - name: Wait for post-process update to complete
+      ansible.builtin.uri:
+        url: "{{ appliance_url }}/appliance-update/post-process/status"
+        method: GET
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+          Authorization: "Bearer {{ access_token }}"
+        return_content: true
+        validate_certs: false
+      register: post_update_status
+      until: post_update_status.json.parameters.status in [0, 3, 5]
+      retries: 30
+      delay: 10
+
+    - name: Fail if post-process update failed
+      ansible.legacy.fail:
+        msg: "Post-process update failed with status code {{ post_update_status.json.parameters.status }}"
+      when: post_update_status.json.parameters.status == 4
+
+    - name: Show post-process progress
+      ansible.builtin.debug:
+        msg: "Post-process status code: {{ post_update_status.json.parameters.status }}"
+      when: post_update_status.json.parameters.status in [1, 2]
+
+    - name: Show complete post-process update status
+      ansible.builtin.debug:
+        var: post_update_status
+
+    - name: Post-process update completed successfully
+      ansible.builtin.debug:
+        msg: "Post-process update completed with status code {{ post_update_status.json.parameters.status }}"

--- a/z_appliance_control_center/other_usecases_ansible/16_get_task_info.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/16_get_task_info.yaml
@@ -1,21 +1,14 @@
 # *+------------------------------------------------------------------------+
-# *| © Copyright IBM Corp. 2025                                             |
-# *| [02.13.2026]                                                           |
-# *|   - Tested with ACC 1.2.12                                             |
-# *|   - Initial release                                                    |
-# *|   - With older ACC versions, replace the 'method: POST' by             |
-# *|     'method: DELETE'                                                   |
-# *|   - Replaced acc_ip with acc_url                                       |
+# *| © Copyright IBM Corp. 2026                                             |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *|   - Initial release                                                    |
 # *| [06.26.2026]                                                           |
 # *|   - Tested with ACC 1.2.14                                             |
 # *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
-# This playbook is tested and updated with ACC version 1.2.12
-
-- name: ACC playbook, run by appliance-owner user, to logout the user
+- name: ACC playbook, run by ACC-owner, to get task information
   hosts: localhost
   gather_facts: true
   vars_files:
@@ -23,10 +16,9 @@
 
   pre_tasks:
     - name: Reminder - Export appliance-owner credentials
-      ansible.legacy.pause:
+      ansible.builtin.pause:
         prompt: |
-          This playbook is tested and updated with ACC version 1.2.12,
-          Before running this playbook, please export appliance-owner credentials:
+          Before running this playbook, please export credentials:
 
           export ACC_OWNER_PASSWORD=<owner_password>
 
@@ -45,30 +37,14 @@
       loop: "{{ required_env_vars }}"
 
   tasks:
-    - name: 00 - Check MFA is enabled or not
-      ansible.builtin.pause:
-        prompt: "Do you have MFA enabled? (yes/no):"
-      register: mfa_enabled_input
-
-    - name: 01 - Set MFA enabled
-      ansible.legacy.set_fact:
-        mfa_enabled: "{{ mfa_enabled_input.user_input | lower == 'yes' }}"
-
-    - name: 02 - Prompt for OTP if MFA is enabled
-      when: mfa_enabled
-      ansible.builtin.pause:
-        prompt: "Enter MFA OTP generated for owner:"
-      register: mfa_otp_input
-
-    - name: 03 - Get authentication token from the ACC as owner
-      tags: owner
+    - name: 00 - Get authentication token from the ACC as appliance-owner
+      tags: owner, install
       ansible.builtin.uri:
         url: "{{ acc_url }}/user/token"
         method: POST
         body:
           username: "{{ cc_owner_user }}"
           password: "{{ cc_owner_password }}"
-          otp: "{{ (mfa_otp_input.user_input if mfa_enabled else omit) }}"
         body_format: json
         return_content: true
         validate_certs: false
@@ -76,24 +52,28 @@
 
     - name: Extract the token
       tags: owner, install
-      ansible.legacy.set_fact:
+      ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
     - name: Display execution info and ACC about information
       ansible.builtin.include_tasks:
         file: common_display_info.yaml
 
-    - name: 04 - Logout appliance-owner
+    - name: Enter the task ID
+      ansible.builtin.pause:
+        prompt: "Enter the task ID (integer):"
+      register: task_id
+
+    - name: Get task status from ACC
       ansible.builtin.uri:
-        url: "{{ acc_url }}/user/logout"
-        method: POST
+        url: "{{ acc_url }}/tasks/{{ task_id.user_input | trim }}/status"
+        method: GET
         headers:
           Authorization: "Bearer {{ access_token }}"
-        status_code: 200
         validate_certs: false
-      register: logout_response
+        return_content: true
+      register: task_status_response
 
-    - name: Printing the response of logout
-      ansible.legacy.debug:
-        msg:
-          - "{{ logout_response.json }}"
+    - name: Display task status response
+      ansible.builtin.debug:
+        var: task_status_response.json

--- a/z_appliance_control_center/other_usecases_ansible/17_tasks_pull_ssc_logs.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/17_tasks_pull_ssc_logs.yaml
@@ -1,0 +1,122 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2026                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Extracted from 03_pull_ssc_logs.yaml for reusability               |
+# *|   - Tasks for pulling SSC/appliance logs                               |
+# *+------------------------------------------------------------------------+
+
+# This task file is not meant to be executed directly. It is automatically called
+# by the following playbooks when run as appliance admin:
+# - other_usecases_ansible/03_pull_ssc_logs.yaml
+# - other_usecases_ansible/18_gather_acc_logs.yaml
+
+# Expected variables:
+# - ssc_ip: SSC LPAR IP address
+# - lpar_username: SSC LPAR username
+# - lpar_password: SSC LPAR password
+# - reason: Reason for creating logs
+# - log_destination: Destination path for the log file
+
+- name: Set API base URL
+  ansible.builtin.set_fact:
+    api_base_url: "https://{{ ssc_ip }}/api/com.ibm.zaci.system"
+
+- name: Get authentication token from the SSC LPAR
+  ansible.builtin.uri:
+    url: "{{ api_base_url }}/api-tokens"
+    method: POST
+    headers:
+      Accept: "application/vnd.ibm.zaci.payload+json"
+      Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+      zACI-API: "com.ibm.zaci.system/1.0"
+    body:
+      kind: "request"
+      parameters:
+        user: "{{ lpar_username }}"
+        password: "{{ lpar_password }}"
+    validate_certs: false
+    return_content: true
+    body_format: json
+  register: ssc_auth_response
+  failed_when: false
+
+- name: Check SSC authentication success
+  ansible.builtin.fail:
+    msg: "SSC authentication failed. Please check your appliance credentials."
+  when: ssc_auth_response.status != 200
+
+- name: Extract the SSC token
+  ansible.builtin.set_fact:
+    ssc_access_token: "{{ ssc_auth_response.json.parameters.token }}"
+
+- name: Send an alert to SSC to create logs
+  ansible.builtin.uri:
+    url: "{{ api_base_url }}/alerts"
+    method: POST
+    headers:
+      Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+      Accept: "application/vnd.ibm.zaci.payload+json;version=1.0"
+      Authorization: "Bearer {{ ssc_access_token }}"
+      zACI-API: "com.ibm.zaci.system/1.0"
+    body:
+      kind: "request"
+      parameters:
+        reason: "Testing alerts because of: {{ reason }}"
+        diag_info: "concurrent"
+    validate_certs: false
+    return_content: true
+    body_format: json
+    status_code: 202
+  register: alert_response
+  failed_when: false
+
+- name: Check alert creation success
+  ansible.builtin.fail:
+    msg: "Failed to create alert on SSC appliance."
+  when: alert_response.status != 202
+
+- name: Extract the alert UUID
+  ansible.builtin.set_fact:
+    alert_uuid: "{{ alert_response.json.parameters.self | regex_search('[0-9a-fA-F-]{36}') }}"
+
+- name: Display extracted UUID
+  ansible.builtin.debug:
+    var: alert_uuid
+
+- name: Wait till alert is handled by SSC
+  ansible.builtin.uri:
+    url: "{{ api_base_url }}/alerts/{{ alert_uuid }}"
+    method: GET
+    headers:
+      Accept: "application/vnd.ibm.zaci.payload+json;version=1.0"
+      Authorization: "Bearer {{ ssc_access_token }}"
+      zACI-API: "com.ibm.zaci.system/1.0"
+    validate_certs: false
+    return_content: false
+    body_format: json
+    status_code: 200
+  register: alert_info
+  until: alert_info.status == 200
+  retries: 60
+  delay: 10
+  failed_when: alert_info.status not in [200, 202]
+
+- name: Display information about the alert
+  ansible.builtin.debug:
+    var: alert_info.json
+
+- name: Download diagnostic info as binary log
+  ansible.builtin.uri:
+    url: "{{ api_base_url }}/alerts/{{ alert_uuid }}/diag-info"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ ssc_access_token }}"
+      zACI-API: "com.ibm.zaci.system/1.0"
+      Accept: "application/octet-stream"
+    validate_certs: false
+    status_code: 200
+    timeout: 180
+    dest: "{{ log_destination }}"
+  register: ssc_download_result

--- a/z_appliance_control_center/other_usecases_ansible/18_gather_acc_logs.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/18_gather_acc_logs.yaml
@@ -1,0 +1,392 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2026                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Initial release                                                    |
+# *|   - Comprehensive log gathering playbook for ACC-admin and owner       |
+# *+------------------------------------------------------------------------+
+
+- name: ACC playbook to gather comprehensive logs (admin/owner)
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - owner_vars.yaml
+
+  vars_prompt:
+    - name: "acc_username"
+      prompt: "Enter ACC username (ACC-admin or appliance-owner)"
+      private: false
+    - name: "acc_password"
+      prompt: "Enter ACC password"
+      private: true
+    - name: "tasks_count"
+      prompt: "Enter number of recent tasks to retrieve (default 100)"
+      private: false
+      default: "100"
+    - name: "history_count"
+      prompt: "Enter number of recent history operations to retrieve (default 100)"
+      private: false
+      default: "100"
+
+  vars:
+    log_base_dir: "./acc_logs"
+
+  tasks:
+    - name: Display playbook execution information
+      ansible.builtin.include_tasks:
+        file: common_display_execution_info.yaml
+
+    - name: 00a - Set timestamp for this run
+      ansible.builtin.set_fact:
+        timestamp: "{{ ansible_facts['date_time']['iso8601_basic_short'] }}"
+
+    - name: 00b - Set log directory path
+      ansible.builtin.set_fact:
+        log_dir: "{{ log_base_dir }}/acc_logs_{{ timestamp }}"
+
+    - name: 00c - Create log directory structure
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ log_dir }}"
+        - "{{ log_dir }}/audit_logs"
+        - "{{ log_dir }}/app_logs"
+
+    - name: 01 - Check if MFA is enabled
+      ansible.builtin.pause:
+        prompt: "Do you have MFA enabled? (yes/no):"
+      register: mfa_enabled_input
+
+    - name: 02 - Set MFA enabled flag
+      ansible.builtin.set_fact:
+        mfa_enabled: "{{ mfa_enabled_input.user_input | lower == 'yes' }}"
+
+    - name: 03 - Prompt for OTP if MFA is enabled
+      when: mfa_enabled
+      ansible.builtin.pause:
+        prompt: "Enter MFA OTP:"
+      register: mfa_otp_input
+
+    - name: 04 - Get authentication token from ACC
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/user/token"
+        method: POST
+        body:
+          username: "{{ acc_username }}"
+          password: "{{ acc_password }}"
+          otp: "{{ (mfa_otp_input.user_input if mfa_enabled else omit) }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+      register: auth_response
+      failed_when: false
+
+    - name: 05 - Check authentication success
+      ansible.builtin.fail:
+        msg: "Authentication failed. Please check your credentials."
+      when: auth_response.status != 200
+
+    - name: 06 - Extract the token and user role
+      ansible.builtin.set_fact:
+        access_token: "{{ auth_response.json.access_token }}"
+        user_role: "{{ auth_response.json.role }}"
+
+    - name: 07 - Set user role flags
+      ansible.builtin.set_fact:
+        is_admin: "{{ user_role == 'admin' }}"
+        is_owner: "{{ user_role == 'owner' }}"
+
+    - name: 08 - Display detected user role
+      ansible.builtin.debug:
+        msg: "Detected user role: {{ user_role }}"
+
+    - name: 09 - Gather ACC about information
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/about"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+        validate_certs: false
+        return_content: true
+      register: about_response
+      failed_when: false
+
+    - name: 10 - Save about API output to file
+      ansible.builtin.copy:
+        content: "{{ about_response.json | to_nice_json }}"
+        dest: "{{ log_dir }}/about.log"
+        mode: "0755"
+      when: about_response.status == 200
+
+    - name: 11 - Display about API status
+      ansible.builtin.debug:
+        msg: "{{ 'About API gathered successfully' if about_response.status == 200 else 'Failed to gather about API info' }}"
+
+    - name: 12 - Gather last n tasks
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/tasks?n={{ tasks_count }}"
+        method: POST
+        body: {}
+        body_format: json
+        headers:
+          Accept: "application/json"
+          Authorization: "Bearer {{ access_token }}"
+        validate_certs: false
+        return_content: true
+      register: tasks_response
+      failed_when: false
+
+    - name: 13 - Save tasks to file
+      ansible.builtin.copy:
+        content: "{{ tasks_response.json | to_nice_json }}"
+        dest: "{{ log_dir }}/tasks.log"
+        mode: "0755"
+      when: tasks_response.status == 200
+
+    - name: 14 - Display tasks gathering status
+      ansible.builtin.debug:
+        msg:
+          - "Tasks API Status: {{ tasks_response.status | default('No response') }}"
+          - "{{ 'Tasks gathered successfully' if tasks_response.status == 200 else 'Failed to gather tasks' }}"
+          - >-
+            {% if tasks_response.status != 200
+              and tasks_response.json is defined %}
+            API Response: {{ tasks_response.json | to_nice_json }}
+            {% elif tasks_response.status != 200 %}
+            Error: {{ tasks_response.msg | default('Unknown error') }}
+            {% endif %}
+
+    - name: 15 - Gather last n history operations
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/history?n={{ history_count }}"
+        method: POST
+        body: {}
+        body_format: json
+        headers:
+          Accept: "application/json"
+          Authorization: "Bearer {{ access_token }}"
+        validate_certs: false
+        return_content: true
+      register: history_response
+      failed_when: false
+
+    - name: 16 - Save history to file
+      ansible.builtin.copy:
+        content: "{{ history_response.json | to_nice_json }}"
+        dest: "{{ log_dir }}/history.log"
+        mode: "0755"
+      when: history_response.status == 200
+
+    - name: 17 - Display history gathering status
+      ansible.builtin.debug:
+        msg:
+          - "History API Status: {{ history_response.status | default('No response') }}"
+          - "{{ 'History gathered successfully' if history_response.status == 200 else 'Failed to gather history' }}"
+          - >-
+            {% if history_response.status != 200
+              and history_response.json is defined %}
+            API Response: {{ history_response.json | to_nice_json }}
+            {% elif history_response.status != 200 %}
+            Error: {{ history_response.msg | default('Unknown error') }}
+            {% endif %}
+
+    - name: 18 - Gather audit logs (ACC-admin only)
+      when: is_admin
+      block:
+        - name: 18a - Fetch audit logs and save directly to file
+          ansible.builtin.uri:
+            url: "{{ acc_url }}/audit"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ access_token }}"
+              Content-Type: "application/json"
+            validate_certs: false
+            dest: "{{ log_dir }}/audit_logs/audit_logs_{{ timestamp }}.zip"
+            status_code: 200
+          register: audit_response
+          failed_when: false
+
+        - name: 18b - Display audit logs gathering status
+          ansible.builtin.debug:
+            msg: >-
+              {{
+                'Audit logs gathered successfully'
+                if audit_response.status == 200
+                else 'Failed to gather audit logs: '
+                    + (audit_response.msg | default('Unknown error'))
+              }}
+
+    - name: 19 - Skip audit logs for appliance-owner
+      when: is_owner
+      ansible.builtin.debug:
+        msg: "Skipping audit logs - only available for ACC-admin users"
+
+    - name: 20 - Gather appliance logs (ACC-admin only)
+      when: is_admin
+      block:
+        - name: 20a - Prompt for appliance credentials
+          ansible.builtin.pause:
+            prompt: "Do you want to gather appliance logs? This requires appliance credentials. (yes/no):"
+          register: gather_app_logs_input
+
+        - name: 20b - Set gather appliance logs flag
+          ansible.builtin.set_fact:
+            gather_app_logs: "{{ gather_app_logs_input.user_input | lower == 'yes' }}"
+
+        - name: 20c - Prompt for appliance IP
+          when: gather_app_logs
+          ansible.builtin.pause:
+            prompt: "Enter appliance (SSC) LPAR IP address:"
+          register: ssc_ip_input
+
+        - name: 20d - Prompt for appliance username
+          when: gather_app_logs
+          ansible.builtin.pause:
+            prompt: "Enter appliance (SSC) LPAR username:"
+          register: ssc_username_input
+
+        - name: 20e - Prompt for appliance password
+          when: gather_app_logs
+          ansible.builtin.pause:
+            prompt: "Enter appliance (SSC) LPAR password:"
+            echo: false
+          register: ssc_password_input
+
+        - name: 20f - Prompt for reason
+          when: gather_app_logs
+          ansible.builtin.pause:
+            prompt: "Enter reason for creating logs:"
+          register: reason_input
+
+        - name: 20g - Set appliance variables
+          when: gather_app_logs
+          ansible.builtin.set_fact:
+            ssc_ip: "{{ ssc_ip_input.user_input }}"
+            lpar_username: "{{ ssc_username_input.user_input }}"
+            lpar_password: "{{ ssc_password_input.user_input }}"
+            reason: "{{ reason_input.user_input }}"
+            log_destination: "{{ log_dir }}/app_logs/ssc_{{ timestamp }}.gz"
+
+        - name: 20h - Include SSC log pulling tasks (reuses 03_pull_ssc_logs.yaml logic)
+          when: gather_app_logs
+          block:
+            - name: Include SSC log tasks
+              ansible.builtin.include_tasks:
+                file: 17_tasks_pull_ssc_logs.yaml
+          rescue:
+            - name: Handle SSC log gathering failure
+              ansible.builtin.set_fact:
+                ssc_download_result:
+                  status: 500
+                  msg: "Failed to gather appliance logs"
+
+        - name: 20i - Display appliance logs gathering status
+          when: gather_app_logs
+          ansible.builtin.debug:
+            msg: >-
+              {{
+                'Appliance logs gathered successfully'
+                if (
+                  ssc_download_result is defined and
+                  ssc_download_result.status == 200
+                )
+                else 'Failed to gather appliance logs'
+              }}
+
+    - name: 21 - Skip appliance logs for appliance-owner
+      when: is_owner
+      ansible.builtin.debug:
+        msg: "Skipping appliance logs - only available for ACC-admin users"
+
+    - name: 22 - Create summary file
+      ansible.builtin.copy:
+        content: |
+          ACC Log Collection Summary
+          ==========================
+          Collection Time: {{ timestamp }}
+          ACC URL: {{ acc_url }}
+          User: {{ acc_username }}
+          User Role: {{ user_role }}
+
+          Files Collected:
+          ----------------
+          - about.log: ACC about information ({{ 'Success' if about_response.status == 200
+          else 'Failed - Status: ' + (about_response.status | string) }})
+          - tasks.log: Last {{ tasks_count }} tasks ({{ 'Success' if tasks_response.status == 200
+          else 'Failed - Status: ' + (tasks_response.status | string) }})
+          {% if tasks_response.status != 200 and tasks_response.json is defined %}
+            API Response: {{ tasks_response.json | to_nice_json }}
+          {% elif tasks_response.status != 200 %}
+            Error: {{ tasks_response.msg | default('Unknown error') }}
+          {% endif %}
+          - history.log: Last {{ history_count }} history operations ({{ 'Success' if history_response.status == 200
+          else 'Failed - Status: ' + (history_response.status | string) }})
+          {% if history_response.status != 200 and history_response.json is defined %}
+            API Response: {{ history_response.json | to_nice_json }}
+          {% elif history_response.status != 200 %}
+            Error: {{ history_response.msg | default('Unknown error') }}
+          {% endif %}
+          {% if is_admin %}
+          - audit_logs/audit_logs_{{ timestamp }}.zip: Audit logs ({{ 'Success' if audit_response.status == 200
+          else 'Failed - Status: ' + (audit_response.status | string) }})
+          {% if gather_app_logs | default(false) %}
+          - app_logs/ssc_{{ timestamp }}.gz: Appliance diagnostic logs ({{ 'Success' if ssc_download_result is defined
+          and ssc_download_result.status == 200 else 'Failed' }})
+          {% endif %}
+          {% else %}
+          - Audit logs: Skipped (requires ACC-admin role)
+          - Appliance logs: Skipped (requires ACC-admin role)
+          {% endif %}
+
+          Log Directory: {{ log_dir }}
+
+          Note: Appliance logs are gathered using reusable tasks from 17_tasks_pull_ssc_logs.yaml
+        dest: "{{ log_dir }}/SUMMARY.txt"
+        mode: "0755"
+
+    - name: 23 - Display completion message header
+      ansible.builtin.debug:
+        msg:
+          - "========================================"
+          - "Log collection completed successfully!"
+          - "========================================"
+          - ""
+          - "All logs have been saved to: {{ log_dir }}"
+          - ""
+          - "Files collected:"
+
+    - name: 24 - Display collected files
+      ansible.builtin.debug:
+        msg: "{{ collected_files }}"
+      vars:
+        collected_files: >-
+          {%- set files = [] -%}
+          {%- if about_response.status == 200 -%}
+            {%- set files = files + ['✓ about.log'] -%}
+          {%- endif -%}
+          {%- if tasks_response.status == 200 -%}
+            {%- set files = files + ['✓ tasks.log (' + tasks_count | string + ' tasks)'] -%}
+          {%- endif -%}
+          {%- if history_response.status == 200 -%}
+            {%- set files = files + ['✓ history.log (' + history_count | string + ' operations)'] -%}
+          {%- endif -%}
+          {%- if is_admin -%}
+            {%- if audit_response.status == 200 -%}
+              {%- set files = files + ['✓ audit_logs/audit_logs_' + timestamp + '.zip'] -%}
+            {%- endif -%}
+            {%- if gather_app_logs | default(false) and ssc_download_result is defined and ssc_download_result.status == 200 -%}
+              {%- set files = files + ['✓ app_logs/ssc_' + timestamp + '.gz'] -%}
+            {%- endif -%}
+          {%- else -%}
+            {%- set files = files + ['⊘ Audit logs (requires ACC-admin)', '⊘ Appliance logs (requires ACC-admin)'] -%}
+          {%- endif -%}
+          {{ files }}
+
+    - name: 25 - Display summary location
+      ansible.builtin.debug:
+        msg:
+          - ""
+          - "See SUMMARY.txt for details."

--- a/z_appliance_control_center/other_usecases_ansible/19_acc_about_info.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/19_acc_about_info.yaml
@@ -1,0 +1,59 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2026                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Initial release                                                    |
+# *|   - Added execution timestamp and ACC about info display               |
+# *+------------------------------------------------------------------------+
+
+- name: ACC playbook to get ACC about information (supports ACC-admin and appliance-owner)
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - owner_vars.yaml
+
+  vars_prompt:
+    - name: cc_username
+      prompt: "Enter your ACC username (admin or owner)"
+      private: false
+
+    - name: cc_password
+      prompt: "Enter your ACC password"
+      private: true
+
+  tasks:
+    - name: 00 - Check if MFA is enabled
+      ansible.builtin.pause:
+        prompt: "Do you have MFA enabled? (yes/no)"
+      register: mfa_enabled_input
+
+    - name: 01 - Set MFA enabled
+      ansible.builtin.set_fact:
+        mfa_enabled: "{{ mfa_enabled_input.user_input | lower == 'yes' }}"
+
+    - name: 02 - Prompt for OTP if MFA is enabled
+      when: mfa_enabled
+      ansible.builtin.pause:
+        prompt: "Enter MFA OTP:"
+      register: mfa_otp_input
+
+    - name: 03 - Get authentication token from the ACC
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/user/token"
+        method: POST
+        body:
+          username: "{{ cc_username }}"
+          password: "{{ cc_password }}"
+          otp: "{{ (mfa_otp_input.user_input if mfa_enabled else omit) }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+      register: auth_response
+
+    - name: 04 - Extract the token
+      ansible.builtin.set_fact:
+        access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml

--- a/z_appliance_control_center/other_usecases_ansible/20_get_preserved_appliance_info.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/20_get_preserved_appliance_info.yaml
@@ -1,0 +1,173 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2026                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Initial release                                                    |
+# *+------------------------------------------------------------------------+
+
+- name: ACC playbook, run as appliance-owner, to get preserved information for inactive appliance
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - owner_vars.yaml
+
+  vars_prompt:
+    - name: "resource_package_name"
+      prompt: "Enter the name of the resource package, or use 'all' to get information about all the resource packages (default: all)"
+      private: false
+      default: "all"
+
+  pre_tasks:
+    - name: Reminder - Export appliance-owner credentials
+      ansible.builtin.pause:
+        prompt: |
+          Before running this playbook, please export appliance-owner credentials:
+
+          export ACC_OWNER_PASSWORD=<owner_password>
+
+          Press Ctrl+C now to cancel if you haven't done this.
+          The playbook will continue shortly.
+        seconds: 5
+
+    - name: Check required environment variables
+      vars:
+        required_env_vars:
+          - ACC_OWNER_PASSWORD
+
+      ansible.builtin.fail:
+        msg: "Missing required environment variable: {{ item }}"
+      when: lookup('env', item) == ""
+      loop: "{{ required_env_vars }}"
+
+  tasks:
+    - name: 00 - Check MFA is enabled or not
+      ansible.builtin.pause:
+        prompt: "Do you have MFA enabled? (yes/no):"
+      register: mfa_enabled_input
+
+    - name: 01 - Set MFA enabled
+      ansible.builtin.set_fact:
+        mfa_enabled: "{{ mfa_enabled_input.user_input | lower == 'yes' }}"
+
+    - name: 02 - Prompt for OTP if MFA is enabled
+      when: mfa_enabled
+      ansible.builtin.pause:
+        prompt: "Enter MFA OTP generated for owner:"
+      register: mfa_otp_input
+
+    - name: 03 - Get authentication token from the ACC as owner
+      tags: owner
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/user/token"
+        method: POST
+        body:
+          username: "{{ cc_owner_user }}"
+          password: "{{ cc_owner_password }}"
+          otp: "{{ (mfa_otp_input.user_input if mfa_enabled else omit) }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+      register: auth_response
+
+    - name: 04 - Extract the token
+      tags: owner
+      ansible.builtin.set_fact:
+        access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: common_display_info.yaml
+
+    - name: 05 - Check if 'all' resource packages requested
+      ansible.builtin.set_fact:
+        fetch_all_packages: "{{ resource_package_name | lower == 'all' }}"
+
+    - name: 06 - Get all resource packages (if 'all' specified)
+      when: fetch_all_packages
+      tags: owner
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/resource/pkgs"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Accept: application/json
+        return_content: true
+        validate_certs: false
+      register: resource_packages_response
+
+    - name: 07 - Extract resource package names (if 'all' specified)
+      when: fetch_all_packages
+      tags: owner
+      ansible.builtin.set_fact:
+        package_names: "{{ resource_packages_response.json | map(attribute='name') | list }}"
+
+    - name: 08 - Display resource packages found (if 'all' specified)
+      when: fetch_all_packages
+      ansible.builtin.debug:
+        msg: "Found {{ package_names | length }} resource package(s): {{ package_names | join(', ') }}"
+
+    - name: 09 - Prompt for LPAR specification preference
+      ansible.builtin.pause:
+        prompt: "Do you want to specify specific LPARs to get the preserved information? (yes/no - 'no' will fetch for all LPARs in the resource package)"
+      register: specify_lpars_input
+
+    - name: 10 - Set specify LPARs flag
+      ansible.builtin.set_fact:
+        specify_lpars: "{{ specify_lpars_input.user_input | lower == 'yes' }}"
+
+    - name: 11 - Prompt for LPAR names if specified
+      when: specify_lpars
+      ansible.builtin.pause:
+        prompt: "Enter LPAR names (comma-separated, e.g., SSC12,SSC09):"
+      register: lpar_names_input
+
+    - name: 12 - Build LPAR list
+      when: specify_lpars
+      ansible.builtin.set_fact:
+        lpar_list: "{{ lpar_names_input.user_input.split(',') | map('trim') | reject('equalto', '') | list }}"
+
+    - name: 13 - Build request body for all resource packages
+      when: fetch_all_packages and not specify_lpars
+      tags: owner
+      ansible.builtin.set_fact:
+        request_body: "{{ dict(package_names | zip_longest([], fillvalue={})) }}"
+
+    - name: 14 - Build request body for all resource packages with specific LPARs
+      when: fetch_all_packages and specify_lpars
+      tags: owner
+      ansible.builtin.set_fact:
+        request_body: "{{ dict(package_names | zip_longest([], fillvalue={'lpars': lpar_list})) }}"
+
+    - name: 15 - Build request body for single package with specific LPARs
+      when: not fetch_all_packages and specify_lpars
+      ansible.builtin.set_fact:
+        request_body: "{{ {} | combine({resource_package_name: {'lpars': lpar_list}}) }}"
+
+    - name: 16 - Build request body for single package with all LPARs
+      when: not fetch_all_packages and not specify_lpars
+      ansible.builtin.set_fact:
+        request_body: "{{ {} | combine({resource_package_name: {}}) }}"
+
+    - name: 17 - Display request body
+      ansible.builtin.debug:
+        var: request_body
+
+    - name: 18 - Get preserved information for inactive appliance
+      tags: owner
+      ansible.builtin.uri:
+        url: "{{ acc_url }}/cluster/inactive-appliance/preserved-info"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ access_token }}"
+          Content-Type: application/json
+        body: "{{ request_body }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+        status_code: [200, 207]
+      register: preserved_info_response
+
+    - name: 19 - Display preserved appliance information response
+      tags: owner
+      ansible.builtin.debug:
+        var: preserved_info_response.json

--- a/z_appliance_control_center/other_usecases_ansible/README.md
+++ b/z_appliance_control_center/other_usecases_ansible/README.md
@@ -25,6 +25,22 @@ The use cases here cover the `default` mode of ACC, with or without MFA enabled.
 If MFA is enabled by the ACC-admin, ensure that you save the admin's and
 owner's `mfa_secret`s.
 
+### Features
+
+- **Execution Timestamp and ACC About Info Display**: Multiple playbooks in this directory now display execution timestamp and ACC about information at the start of execution for better tracking and debugging. This includes:
+  - `00_resource_scan.yaml`
+  - `01_upgrade_flow.yaml`
+  - `02_sync_cpc_lpars.yaml`
+  - `04_managed_appliance_update.yaml`
+  - `05_managed_appliance_health_and_pull_logs.yaml`
+  - `07_insert_hmc_creds.yaml`
+  - `10_unlock_appliances.yaml`
+  - `12_logout_owner.yaml`
+  - `13_restart_appliances.yaml`
+  - `16_get_task_info.yaml`
+  - `19_acc_about_info.yaml`
+  - `20_get_preserved_appliance_info.yaml`
+
 ## Preparation
 
 - Almost all the playbooks here require that ACC and the appliances under

--- a/z_appliance_control_center/other_usecases_ansible/README.md
+++ b/z_appliance_control_center/other_usecases_ansible/README.md
@@ -15,6 +15,11 @@ These playbooks can be used for:
 - Unlocking appliances
 - Restarting ACC
 - Logging out of ACC
+- Exporting ACC configuration
+- Restoring ACC configuration (post-process task, available from ACC version 1.2.10 and above)
+- Gathering comprehensive ACC logs (tasks, history, audit, about, and appliance logs)
+- Getting ACC about information
+
 
 The use cases here cover the `default` mode of ACC, with or without MFA enabled.
 If MFA is enabled by the ACC-admin, ensure that you save the admin's and
@@ -61,22 +66,76 @@ playbook might delete all your unsaved data.
 To upgrade or update an appliance, perform the following actions as
 appliance-owner.
 
-- Download the appliance image you want to install to your control node (e.g., 
-  your laptop).
-- Modify the location of that image file for upgrade in the `owner_vars.yaml` file.
-  - Specifically, change the `image_path` variable.
-  - This image is used for both upgrade and concurrent/fix update.
-  - The variable `image_type` denotes the kind of update:
-    - Set the `image_type` variable to `image` for upgrade.
-      - Run the playbook for appliance upgrade:
-        ```bash
-        ansible-playbook 01_upgrade_flow.yaml
-        ```
-    - Set the `image_type` variable to `fix` for concurrent update.
-      - Run the playbook for appliance concurrent :
-        ```bash
-        ansible-playbook 04_managed_appliance_update.yaml
-        ```
+### 01_upgrade_flow.yaml
+
+Use `01_upgrade_flow.yaml` when you want to perform a full appliance upgrade
+using an uploaded image.
+
+- Download the appliance image you want to install to your control node.
+- Update `owner_vars.yaml`:
+  - `image_path`: path to the upgrade image file
+  - `package_name`: resource package that owns the target appliance
+  - `lpar_name`: target LPAR name
+  - `acc_url`: ACC API endpoint
+- Export the required environment variable:
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_password>
+  ```
+- Run the playbook:
+  ```bash
+  ansible-playbook 01_upgrade_flow.yaml
+  ```
+
+Behavior of this playbook:
+- Prompts for MFA OTP if MFA is enabled.
+- Uploads the image to ACC.
+- If the same image already exists for the current owner, the playbook lets you:
+  - continue with an existing uploaded image, or
+  - stop and re-run after deleting/changing the image
+- If you continue with an existing image, the playbook lists all available images
+  and asks you to select the image ID interactively.
+- Sends the cluster upgrade request using the selected/uploaded image ID.
+- Saves the upgrade response body to the path configured by
+  `upgrade_appliance_data`.
+- Saves response headers to:
+  `{{ upgrade_appliance_data }}.headers`
+- Fails the playbook if ACC returns HTTP `400`, while still preserving the
+  downloaded response for inspection.
+- Prints a warning if ACC returns HTTP `207`.
+
+### 04_managed_appliance_update.yaml
+
+Use `04_managed_appliance_update.yaml` when you want to apply a concurrent
+update/fix bundle to an existing appliance.
+
+- Update `owner_vars.yaml`:
+  - `update_bundle_path`: path to the update bundle file
+  - `package_name`: resource package that owns the target appliance
+  - `lpar_name`: target LPAR name
+  - `acc_url`: ACC API endpoint
+- Export the required environment variables:
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_password>
+  ```
+- Run the playbook:
+  ```bash
+  ansible-playbook 04_managed_appliance_update.yaml
+  ```
+
+Behavior of this playbook:
+- Prompts for MFA OTP if MFA is enabled.
+- Uploads the fix/update bundle to ACC.
+- Detects HTML error responses from the upload step and fails with a clearer
+  message for invalid requests or authentication problems.
+- If the same image already exists for the current owner, the playbook lets you:
+  - continue with an existing uploaded image, or
+  - stop and re-run after deleting/changing the image
+- If you continue with an existing image, the playbook lists all available images
+  and asks you to select the image ID interactively.
+- Unlocks quota for discovered running appliances by prompting for username and password interactively for each appliance.
+- Starts the concurrent update using the selected/uploaded image ID.
+- Saves the update response ZIP to the path configured by `upgrade_fix_data`.
+- Prints a warning if ACC returns HTTP `207`.
 
 ## Sync ACC with HMC | 02_sync_cpc_lpars.yaml
 
@@ -132,6 +191,8 @@ ansible-playbook 02_sync_cpc_lpars.yaml
 This playbook will interactively ask for the IP, username and password of the
 SSC LPAR of the appliance, from which logs are gathered. This means that this playbook can also be
 used for gathering logs from other appliances (e.g., SSA appliance).
+
+**Note**: This playbook now uses the reusable `17_tasks_pull_ssc_logs.yaml` tasks file, which contains the core log gathering logic. This same tasks file is also used by `18_gather_acc_logs.yaml` for consistency.
 
 Note that this playbook waits and then asks the SSC appliance
 whether the alert is handled by the appliance. If the alert is not yet
@@ -235,6 +296,14 @@ For this purpose:
   ```bash
     ansible-playbook 07_insert_hmc_creds.yaml
   ```
+
+### Optional: HMC Credential Expiry
+
+This playbook now supports an optional parameter to set an expiry time for HMC credentials.
+When prompted during playbook execution:
+
+- **Enter a number between 1-14** to set the HMC credentials to expire after that many days
+- **Leave empty** (press Enter) - on leaving empty we do not pass credential expiry time and hence ACC takes the default expiry of 1 day
 
 ### Caution:
 
@@ -376,3 +445,205 @@ To restart the appliances, follow the procedure:
   ```bash
   ansible-playbook 13_restart_appliances.yaml
   ```
+
+## Export ACC Configuration | 14_acc_export_config.yaml
+
+This playbook allows the ACC administrator to export the current ACC configuration
+to a file. The exported configuration can be used to restore ACC to a previous
+state in case of failures or to migrate configuration to another ACC instance.
+
+The playbook will:
+- Authenticate with ACC using admin credentials
+- Export the ACC configuration
+- Save the configuration file with a timestamp in the filename
+- Display the export location with a security reminder
+
+**Important**: The exported configuration file should be saved to a secure location
+as it may contain sensitive information. You will need this file to restore ACC
+configuration in case of failures.
+
+To export ACC configuration:
+
+- Update the variables in `export_import_vars.yaml`:
+  - Set the `export_dir` to specify where the configuration file should be saved
+  - Set the `lpar_name` if needed for your environment
+- Run the playbook:
+  ```bash
+  ansible-playbook 14_acc_export_config.yaml
+  ```
+- The playbook will prompt for:
+  - ACC IP address
+  - ACC admin username
+  - ACC admin password
+
+The exported file will be saved with a timestamp in the format:
+`{LPAR_NAME}_ACC_config_{TIMESTAMP}.data`
+
+## Restore ACC Configuration | 15_acc_restore_config.yaml
+
+This playbook allows the ACC administrator to restore a previously exported ACC
+configuration. This is useful for:
+- Recovering from configuration errors
+- Restoring ACC after a failure
+- Migrating configuration between ACC instances
+
+The playbook will:
+- Validate that the import file exists
+- Display import file information including filename with timestamp
+- Extract and display metadata from the import file (comment, date, message type)
+- Pause for 10 seconds before importing to allow review
+- Import the configuration and apply it
+- Wait for ACC to restart and become operational
+- Re-authenticate after the restart
+- Post-install script is executed after the config import(available from ACC 1.2.10 and above)
+
+**Important**: Restoring configuration will overwrite the current ACC configuration
+and restart the ACC appliance. Ensure you have a backup of the current configuration
+before proceeding.
+
+To restore ACC configuration:
+
+- Ensure you have a previously exported configuration file
+- Run the playbook:
+  ```bash
+  ansible-playbook 15_acc_restore_config.yaml
+  ```
+- The playbook will prompt for:
+  - ACC IP address
+  - ACC admin username
+  - ACC admin password
+  - Full path to the exported configuration file
+
+The playbook will display the import file metadata and pause for 10 seconds before proceeding with the import, giving you time to verify the correct file is being used.
+
+## Gather Comprehensive ACC Logs | 18_gather_acc_logs.yaml
+
+This playbook provides a unified solution for gathering all ACC-related logs and information in a single execution. It automatically detects the user role (ACC-admin or appliance-owner) and collects appropriate logs based on permissions.
+
+**Code Reuse**: Both this playbook and `03_pull_ssc_logs.yaml` use the same `17_tasks_pull_ssc_logs.yaml` tasks file for appliance log gathering. This ensures:
+- Single source of truth for log gathering logic
+- Consistent behavior across playbooks
+- Easier maintenance and bug fixes
+
+The playbook gathers:
+- **Tasks log**: Last n tasks from ACC
+- **History log**: Last n history operations from ACC
+- **About information**: ACC version and configuration details
+- **Audit logs**: Available only for ACC-admin users
+- **Appliance logs**: Available only for ACC-admin users (requires appliance credentials)
+
+All logs are organized in a timestamped directory structure:
+```
+acc_logs/
+└── acc_logs_YYYYMMDD_HHMMSS/
+    ├── tasks.log
+    ├── history.log
+    ├── about.log
+    ├── audit_logs/
+    │   └── audit_logs_YYYYMMDD_HHMMSS.zip
+    ├── app_logs/
+    │   └── ssc_YYYYMMDD_HHMMSS.gz
+    └── SUMMARY.txt
+```
+
+### Features
+
+- **Uses vars file**: Reads ACC URL from `owner_vars.yaml` (consistent with other playbooks)
+- **Interactive prompts**: Minimal prompts for credentials and parameters
+- **Role-based access**: Automatically detects user role and adjusts log collection
+- **MFA support**: Handles Multi-Factor Authentication if enabled
+- **Graceful error handling**: Skips tasks that fail due to insufficient permissions
+- **Comprehensive summary**: Generates a summary file with collection status
+
+### Prerequisites
+
+Before running the playbook, ensure you have configured `owner_vars.yaml` with the `acc_url` variable (e.g., `https://9.152.150.225:8081/api`)
+
+### Usage
+
+Run the playbook:
+```bash
+ansible-playbook 18_gather_acc_logs.yaml
+```
+
+The playbook will interactively prompt for:
+1. ACC username (ACC-admin or appliance-owner)
+2. ACC password
+3. Number of recent tasks to retrieve (default: 100)
+4. Number of recent history operations to retrieve (default: 100)
+5. MFA OTP (if MFA is enabled)
+6. Appliance credentials (if ACC-admin and wants to gather appliance logs)
+
+### Role-Based Behavior
+
+**For ACC-admin users:**
+- Collects all logs including audit logs
+- Optionally collects appliance diagnostic logs (requires appliance credentials)
+- Full access to all ACC APIs
+
+**For appliance-owner users:**
+- Collects tasks, history, and about information
+- Skips audit logs (requires admin privileges)
+- Skips appliance logs (requires admin privileges)
+
+### Notes
+
+- The playbook creates a new timestamped directory for each execution
+- Failed API calls are handled gracefully and logged in the summary
+- Appliance log collection may take several minutes as it waits for the appliance to generate diagnostic information
+- All logs are saved in JSON format for easy parsing and analysis
+
+### Example Output
+
+After successful execution, you'll see:
+```
+========================================
+Log collection completed successfully!
+========================================
+
+All logs have been saved to: ./acc_logs/acc_logs_20260520_123045
+
+Files collected:
+✓ about.log
+✓ tasks.log (100 tasks)
+✓ history.log (100 operations)
+✓ audit_logs/audit_logs_20260520_123045.zip
+✓ app_logs/ssc_20260520_123045.gz
+
+See SUMMARY.txt for details.
+```
+
+### Troubleshooting
+
+- If authentication fails, verify your credentials and try again
+- If MFA is enabled, ensure you enter the OTP within the validity period
+- For appliance log collection, ensure the appliance is accessible and credentials are correct
+- Check the SUMMARY.txt file for detailed status of each log collection operation
+
+### Replaces Previous Playbooks
+
+This comprehensive playbook consolidates functionality from:
+- Individual ssc log pull playbook - Now included inside app_logs
+- Individual about info playbook - Now included as about.log
+
+You can continue using the individual playbooks if you only need specific information, but this playbook provides a complete diagnostic package in one execution.
+
+## About Information of ACC | 19_acc_about_info.yaml
+
+This playbook allows both ACC-admin and appliance-owner to query the ACC `/about` API and
+display server version and build information.
+
+To get ACC about information:
+
+- Run the playbook:
+  ```bash
+  ansible-playbook 19_acc_about_info.yaml
+  ```
+- The playbook will prompt for:
+  - ACC username (admin or owner)
+  - ACC password
+  - MFA status (yes/no)
+  - OTP (if MFA is enabled)
+
+The playbook prints the full response returned by the ACC `/about` API.
+

--- a/z_appliance_control_center/other_usecases_ansible/admin_vars.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/admin_vars.yaml
@@ -8,6 +8,8 @@
 # *|   - Replaced hmc_url with hmc_ip                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
 
 ##### ACC variables #######
@@ -21,7 +23,7 @@ acc_port: 8081
 ##### HMC #######
 
 # hmc host ip (e.g., 9.0.0.0)
-hmc_ip: "9.152.150.166"
+hmc_ip: "9.152.150.67"
 
 # ACC-admin's user name on the HMC (e.g., export HMC_USER=xyz.ibm.com)
 hmc_user: "{{ lookup('env', 'HMC_USER') }}"

--- a/z_appliance_control_center/other_usecases_ansible/common_display_execution_info.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/common_display_execution_info.yaml
@@ -1,0 +1,16 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2026                                             |
+# *| Common task for displaying playbook execution information only.        |
+# *| This file is included by other playbooks for reusability.              |
+# *+------------------------------------------------------------------------+
+
+- name: Display playbook execution information
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "Playbook Execution Information"
+      - "=========================================="
+      - "Run Date: {{ ansible_facts['date_time']['date'] }}"
+      - "Run Time: {{ ansible_facts['date_time']['time'] }} {{ ansible_facts['date_time']['tz'] }}"
+      - "Timestamp: {{ ansible_facts['date_time']['iso8601'] }}"
+      - "=========================================="

--- a/z_appliance_control_center/other_usecases_ansible/common_display_info.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/common_display_info.yaml
@@ -1,0 +1,38 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2026                                             |
+# *| Common tasks for displaying playbook execution information and         |
+# *| ACC about information. Requires access_token and acc_url variables.    |
+# *+------------------------------------------------------------------------+
+
+- name: Display playbook execution information
+  ansible.builtin.include_tasks:
+    file: common_display_execution_info.yaml
+
+- name: Get ACC about information
+  ansible.builtin.uri:
+    url: "{{ acc_url }}/about"
+    method: GET
+    headers:
+      Accept: "application/json"
+      Authorization: "Bearer {{ access_token }}"
+    validate_certs: false
+    return_content: true
+  register: about_response
+  failed_when: false
+
+- name: Display ACC about information
+  ansible.builtin.debug:
+    var: about_response.json
+  when: about_response.status == 200
+
+- name: Display about API failure message
+  ansible.builtin.debug:
+    msg: >-
+      Failed to retrieve ACC about information - Status: {{ about_response.status }}.
+      This endpoint may not be available in your ACC version. Available in ACC versions >= 1.2.14.
+      API Response: {{
+        (about_response.content | from_json).message
+        if about_response.content is defined
+        else 'No response received'
+      }}
+  when: about_response.status != 200

--- a/z_appliance_control_center/other_usecases_ansible/export_import_vars.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/export_import_vars.yaml
@@ -1,0 +1,18 @@
+# *+------------------------------------------------------------------------+
+# *| © Copyright IBM Corp. 2025                                             |
+# *| [10.17.2025]                                                           |
+# *|   - Tested with ACC 1.2.6                                              |
+# *|   - Initial release                                                    |
+# *| [12.12.2025]                                                           |
+# *|   - Tested with ACC 1.2.10                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *+------------------------------------------------------------------------+
+
+# Export directory relative to the playbook location
+# Example:
+#   <repo>/other_usecases_ansible/export_data
+export_dir: "{{ playbook_dir }}/export_data"
+
+# LPAR name for resource assignment (e.g., "BLUEC1") should be valid lpar name in which "image" will be installed
+lpar_name: "SSC16"

--- a/z_appliance_control_center/other_usecases_ansible/owner_vars.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/owner_vars.yaml
@@ -10,11 +10,12 @@
 # *|   - Replaced acc_ip with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
-
 
 ####### Users #######
 
@@ -27,7 +28,6 @@ cc_owner_email: "cc_owner@email.com"
 # Owner's password (e.g., "defaultPassw0rd1")
 cc_owner_password: "{{ lookup('env', 'ACC_OWNER_PASSWORD') }}"
 
-
 ####### Resources that are assigned to the appliance-owner #######
 
 # Already created Resource package name (e.g., "RP01")
@@ -35,7 +35,6 @@ package_name: "RP16"
 
 # LPAR name for resource assignment (e.g., "BLUEC1") should be valid lpar name in which "image" will be installed
 lpar_name: "CC16"
-
 
 ####### Image #######
 
@@ -95,7 +94,6 @@ image_type: "image"
 # This is the fix type of image
 image_fix_type: "fix"
 
-
 ####### Image install #######
 
 # ***************************************************************************
@@ -124,7 +122,6 @@ app_cores: 2
 # Amount of memory (in MB) allocated for the image
 app_memory: 51200
 
-
 ####### Appliance credential #######
 
 # Set Username for the appliance (used during appliance installation)
@@ -146,14 +143,13 @@ app_password: "{{ lookup('env', 'APP_PASSWORD') }}"
 
 execution_action: "default"
 
-
 ####### Download zip files #######
 
 # The location where the upgrade ZIP file is downloaded
-upgrade_appliance_data: "{{ lookup('env','HOME') }}/Downloads/upgrade_data_{{ ansible_date_time.epoch }}.zip"
+upgrade_appliance_data: "{{ lookup('env','HOME') }}/Downloads/upgrade_data_{{ ansible_facts['date_time']['epoch'] }}.zip"
 
 # The location where the concurrent update ZIP file is downloaded
-upgrade_fix_data: "{{ lookup('env','HOME') }}/Downloads/upgrade_fixes_data_{{ ansible_date_time.epoch }}.zip"
+upgrade_fix_data: "{{ lookup('env','HOME') }}/Downloads/upgrade_fixes_data_{{ ansible_facts['date_time']['epoch'] }}.zip"
 
 # # The location where the ssa log files is downloaded
 ssa_logs: "{{ lookup('env','HOME') }}/Downloads/download_logs_{{ ansible_date_time.epoch }}.zip"

--- a/z_appliance_control_center/ssa_deploy_ansible/01_ssa_install_e2e_default.yaml
+++ b/z_appliance_control_center/ssa_deploy_ansible/01_ssa_install_e2e_default.yaml
@@ -17,6 +17,16 @@
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Updated task ID extraction to support both 'task-id' and           |
+# *|     'task_id' formats for backward/forward compatibility               |
+# *|   - Added automatic rollback debug messages when activation fails      |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Added optional HMC credential expiry support                       |
 # *+------------------------------------------------------------------------+
 
 # Tested with OSA and FCP devices, on non-DPM mode machine.
@@ -108,18 +118,29 @@
       prompt: "Do you want to initialize ACC? If you have already, then please type no. (yes/no)"
       private: false
       default: "yes"
-    
+
     - name: update_pass
       prompt: "Do you want to update the admin password? If you have already, then please type no (yes/no)"
       private: false
       default: "yes"
-    
+
     - name: update_owner_pass
       prompt: "Do you want to update the owner password? If you have already, then please type no (yes/no)"
       private: false
       default: "yes"
 
+    - name: days_to_clear_hmc_creds
+      prompt: "Enter HMC credential expiry in days (1-14, or leave empty to skip)"
+      private: false
+      default: ""
+
   tasks:
+    - name: 00a - Validate expiry days if provided
+      ansible.builtin.fail:
+        msg: "Invalid value for days_to_clear_hmc_creds. Enter an integer from 1 to 14, or leave empty to skip."
+      when:
+        - days_to_clear_hmc_creds != ""
+        - (days_to_clear_hmc_creds is not match('^[0-9]+$') or days_to_clear_hmc_creds | int < 1 or days_to_clear_hmc_creds | int > 14)
 
     - name: Prepare execution_action
       tags: retry
@@ -161,9 +182,8 @@
           - "Please copy this TOTP secret and generate OTP using any authenticator app to update admin password:"
           - "{{ init_response.json.totp_secret }}"
       when:
-          - mfa_enabled | bool
-          - run_init | lower == "yes"
-
+        - mfa_enabled | bool
+        - run_init | lower == "yes"
 
     - name: Wait for user to generate OTP from totp_secret
       tags: admin
@@ -171,8 +191,8 @@
         prompt: "Enter OTP generated from the above totp_secret:"
       register: otp_input
       when:
-          - mfa_enabled | bool
-          - run_init | lower == "yes"
+        - mfa_enabled | bool
+        - run_init | lower == "yes"
 
     - name: 01 - Update ACC-admin password
       tags: admin
@@ -203,19 +223,16 @@
           - "Admin Password updated successfully. The following is your MFA secret. Paste this into your authenticator app."
           - ---- **** IMPORTANT ****: This secret will be displayed only once. Please save it securely. ----:"
           - "{{ update_password_response.json.mfa_secret }}"
-      when: 
+      when:
         - mfa_enabled | bool
         - update_pass | lower == "yes"
-
 
     - name: Wait for user to generate admin OTP with mfa_secret
       tags: admin, retry
       ansible.builtin.pause:
         prompt: "Enter OTP generated from the above admin mfa_secret:"
       register: mfa_admin_otp_input
-      when: 
-        - mfa_enabled | bool
-        - update_pass | lower == "yes"
+      when: mfa_enabled | bool
 
     - name: 02 - Get authentication token from the ACC as admin
       tags: admin, retry
@@ -236,6 +253,10 @@
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
 
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
+
     - name: 03 - Set HMC configuration in the ACC (default mode, can take 10 mins)
       tags: admin, retry
       ansible.builtin.uri:
@@ -247,6 +268,7 @@
           userid: "{{ hmc_user }}"
           password: "{{ hmc_password }}"
           verify_cert: false
+          days_to_clear_hmc_creds: "{{ (days_to_clear_hmc_creds | int) if days_to_clear_hmc_creds != '' else omit }}"
         body_format: json
         headers:
           Authorization: "Bearer {{ access_token }}"
@@ -331,7 +353,6 @@
               Select the correct disk type based on the system configuration.
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
-
 
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:
@@ -510,16 +531,15 @@
         return_content: true
         validate_certs: false
       register: totp_response
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
-      
 
     - name: Print create owner totp secret response
       tags: owner
       ansible.builtin.debug:
         var: totp_response.json
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -529,7 +549,7 @@
         msg:
           - "Please copy this TOTP secret and generate OTP using any authenticator app to update owner password:"
           - "{{ totp_response.json.secret }}"
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -538,7 +558,7 @@
       ansible.builtin.pause:
         prompt: "Enter owner OTP generated from the above totp_secret:"
       register: otp_input
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -562,7 +582,7 @@
       tags: owner
       ansible.builtin.debug:
         var: owner_update_password_response.json
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -573,7 +593,7 @@
           - "Owner Password updated successfully. The following is your MFA secret. Paste this into your authenticator app."
           - ---- **** IMPORTANT ****: This secret will be displayed only once. Please save it securely. ----:"
           - "{{ owner_update_password_response.json.mfa_secret }}"
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -582,7 +602,7 @@
       ansible.builtin.pause:
         prompt: "Enter OTP generated from the above owner mfa_secret:"
       register: mfa_owner_otp_input
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -706,12 +726,17 @@
             response.json
             | dict2items
             | map(attribute='value')
+            | select('mapping')
             | map('dict2items')
             | flatten
             | map(attribute='value')
-            | selectattr('task-id', 'defined')
-            | map(attribute='task-id')
+            | select('mapping')
+            | map('dict2items')
+            | flatten
+            | selectattr('key', 'in', ['task-id', 'task_id'])
+            | map(attribute='value')
             | list
+            | default([])
           }}
 
     - name: Print extracted task IDs
@@ -740,15 +765,15 @@
         headers:
           Authorization: "Bearer {{ access_token }}"
         validate_certs: false
-        return_content: yes
+        return_content: true
       loop: "{{ task_ids }}"
       loop_control:
         label: "Task {{ item }}"
       register: poll_status
-      retries: 45       # max retries
-      delay: 40         # wait between retries
+      retries: 45 # max retries
+      delay: 40 # wait between retries
       until: poll_status.json["action-status"] in ["Success", "Failed"]
-      failed_when: false 
+      failed_when: false
 
     - name: Evaluate all task results
       ansible.builtin.set_fact:
@@ -759,11 +784,36 @@
             | map(attribute='item')
             | list
           }}
+        acc_failed_lpars: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json.lpar')
+            | list
+          }}
+
+    - name: Debug message - Automatic rollback information
+      tags: owner, install, retry
+      ansible.builtin.debug:
+        msg: |
+          ⚠️  ACTIVATION FAILED - AUTOMATIC ROLLBACK IN PROGRESS ⚠️
+
+          One or more activation tasks have failed.
+          Failed Task IDs: {{ acc_failed_tasks }}
+
+          NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
     - name: Fail play if any task failed
       ansible.builtin.fail:
-        msg: "❌ One or more ACC install tasks failed. Failed Task IDs: {{ acc_failed_tasks }}"
+        msg: |
+          ❌ One or more ACC install tasks failed.
+          Failed Task IDs: {{ acc_failed_tasks }}.
+          ACC has automatically rolled back LPAR(s)
+          {{ acc_failed_lpars | join(', ') }}
+          to deactivate state.
       when: acc_failed_tasks | length > 0
-   
+
     - name: "Success message if both completed"
       ansible.builtin.debug:
         msg: "✅ Both tasks finished successfully or one succeeded and the other failed."

--- a/z_appliance_control_center/ssa_deploy_ansible/01_ssa_install_e2e_default.yaml
+++ b/z_appliance_control_center/ssa_deploy_ansible/01_ssa_install_e2e_default.yaml
@@ -23,9 +23,6 @@
 # *|   - Updated task ID extraction to support both 'task-id' and           |
 # *|     'task_id' formats for backward/forward compatibility               |
 # *|   - Added automatic rollback debug messages when activation fails      |
-# *| [06.26.2026]                                                           |
-# *|   - Tested with ACC 1.2.14                                             |
-# *|   - Added execution timestamp and ACC about info display               |
 # *|   - Added optional HMC credential expiry support                       |
 # *+------------------------------------------------------------------------+
 
@@ -791,6 +788,13 @@
             | map(attribute='json.lpar')
             | list
           }}
+        acc_failed_task_details: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json')
+            | list
+          }}
 
     - name: Debug message - Automatic rollback information
       tags: owner, install, retry
@@ -802,6 +806,11 @@
           Failed Task IDs: {{ acc_failed_tasks }}
 
           NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
+    - name: "FAILED - Task Details"
+      ansible.builtin.debug:
+        var: acc_failed_task_details
       when: acc_failed_tasks | length > 0
 
     - name: Fail play if any task failed

--- a/z_appliance_control_center/ssa_deploy_ansible/02_ssa_install_e2e_standalone.yaml
+++ b/z_appliance_control_center/ssa_deploy_ansible/02_ssa_install_e2e_standalone.yaml
@@ -13,6 +13,12 @@
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Asking to update password before continuing                        |
 # *|   - Changed return code from 200 to 200,207                            |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
+# *|   - Updated task ID extraction to support both 'task-id' and           |
+# *|     'task_id' formats for backward/forward compatibility               |
+# *|   - Added automatic rollback debug messages when activation fails      |
 # *+------------------------------------------------------------------------+
 
 # Tested with OSA and FCP devices, on non-DPM mode machine.
@@ -99,19 +105,18 @@
       prompt: "Do you want to initialize ACC? If you have already, then please type no. (yes/no)"
       private: false
       default: "yes"
-    
+
     - name: update_pass
       prompt: "Do you want to update the admin password? If you have already, then please type no (yes/no)"
       private: false
       default: "yes"
-    
+
     - name: update_owner_pass
       prompt: "Do you want to update the owner password? If you have already, then please type no (yes/no)"
       private: false
       default: "yes"
 
   tasks:
-
     - name: Prepare execution_action
       tags: retry
       ansible.builtin.set_fact:
@@ -152,8 +157,8 @@
           - "Please copy this TOTP secret and generate OTP using any authenticator app to update admin password:"
           - "{{ init_response.json.totp_secret }}"
       when:
-          - mfa_enabled | bool
-          - run_init | lower == "yes"
+        - mfa_enabled | bool
+        - run_init | lower == "yes"
 
     - name: Wait for user to generate OTP from totp_secret
       tags: admin
@@ -161,8 +166,8 @@
         prompt: "Enter OTP generated from the above totp_secret:"
       register: otp_input
       when:
-          - mfa_enabled | bool
-          - run_init | lower == "yes"
+        - mfa_enabled | bool
+        - run_init | lower == "yes"
 
     - name: 01 - Update ACC-admin password (remove this if already done)
       tags: admin
@@ -193,7 +198,7 @@
           - "Admin Password updated successfully. The following is your MFA secret. Paste this into your authenticator app."
           - ---- **** IMPORTANT ****: This secret will be displayed only once. Please save it securely. ----:"
           - "{{ update_password_response.json.mfa_secret }}"
-      when: 
+      when:
         - mfa_enabled | bool
         - update_pass | lower == "yes"
 
@@ -202,9 +207,7 @@
       ansible.builtin.pause:
         prompt: "Enter OTP generated from the above admin mfa_secret:"
       register: mfa_admin_otp_input
-      when: 
-        - mfa_enabled | bool
-        - update_pass | lower == "yes"
+      when: mfa_enabled | bool
 
     - name: 02 - Get authentication token from the ACC as admin
       tags: admin, retry
@@ -224,6 +227,10 @@
       tags: admin, retry
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 03 - Insert CPC information in ACC with dummy values (standalone mode)
       tags: admin
@@ -322,7 +329,6 @@
                 - For FCP disk, ensure that valid values for 'wwpn*' and 'lun*' are provided
                 - For DASD disk, the 'wwpn' and 'lun' values are not required
 
-                
         - name: Enter boot disk type for 1st LPAR [DASD/FCP]
           ansible.builtin.pause:
             prompt: "Enter boot disk type for LPAR {{ lpar1_name }}: (DASD/FCP)"
@@ -489,7 +495,7 @@
         return_content: true
         validate_certs: false
       register: totp_response
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -497,7 +503,7 @@
       tags: owner
       ansible.builtin.debug:
         var: totp_response.json
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -507,7 +513,7 @@
         msg:
           - "Please copy this TOTP secret and generate OTP using any authenticator app to update owner password:"
           - "{{ totp_response.json.secret }}"
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -516,7 +522,7 @@
       ansible.builtin.pause:
         prompt: "Enter owner OTP generated from the above totp_secret:"
       register: otp_input
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -540,7 +546,7 @@
       tags: owner
       ansible.builtin.debug:
         var: owner_update_password_response.json
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -551,7 +557,7 @@
           - "Owner Password updated successfully. The following is your MFA secret. Paste this into your authenticator app."
           - ---- **** IMPORTANT ****: This secret will be displayed only once. Please save it securely. ----:"
           - "{{ owner_update_password_response.json.mfa_secret }}"
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -560,7 +566,7 @@
       ansible.builtin.pause:
         prompt: "Enter OTP generated from the above owner mfa_secret:"
       register: mfa_owner_otp_input
-      when: 
+      when:
         - mfa_enabled | bool
         - update_owner_pass | lower == "yes"
 
@@ -750,12 +756,17 @@
             response.json
             | dict2items
             | map(attribute='value')
+            | select('mapping')
             | map('dict2items')
             | flatten
             | map(attribute='value')
-            | selectattr('task-id', 'defined')
-            | map(attribute='task-id')
+            | select('mapping')
+            | map('dict2items')
+            | flatten
+            | selectattr('key', 'in', ['task-id', 'task_id'])
+            | map(attribute='value')
             | list
+            | default([])
           }}
 
     - name: Print extracted task IDs
@@ -784,15 +795,15 @@
         headers:
           Authorization: "Bearer {{ access_token }}"
         validate_certs: false
-        return_content: yes
+        return_content: true
       loop: "{{ task_ids }}"
       loop_control:
         label: "Task {{ item }}"
       register: poll_status
-      retries: 45       # max retries
-      delay: 40         # wait between retries
+      retries: 45 # max retries
+      delay: 40 # wait between retries
       until: poll_status.json["action-status"] in ["Success", "Failed"]
-      failed_when: false 
+      failed_when: false
 
     - name: Evaluate all task results
       ansible.builtin.set_fact:
@@ -803,12 +814,35 @@
             | map(attribute='item')
             | list
           }}
+        acc_failed_lpars: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json.lpar')
+            | list
+          }}
+
+    - name: Debug message - Automatic rollback information
+      ansible.builtin.debug:
+        msg: |
+          ⚠️  ACTIVATION FAILED - AUTOMATIC ROLLBACK IN PROGRESS ⚠️
+
+          One or more activation tasks have failed.
+          Failed Task IDs: {{ acc_failed_tasks }}
+
+          NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
     - name: Fail play if any task failed
       ansible.builtin.fail:
-        msg: "❌ One or more ACC install tasks failed. Failed Task IDs: {{ acc_failed_tasks }}"
+        msg: |
+          ❌ One or more ACC install tasks failed.
+          Failed Task IDs: {{ acc_failed_tasks }}.
+          ACC has automatically rolled back LPAR(s)
+          {{ acc_failed_lpars | join(', ') }}
+          to deactivate state.
       when: acc_failed_tasks | length > 0
-   
+
     - name: "Success message if both completed"
       ansible.builtin.debug:
         msg: "✅ Both tasks finished successfully or one succeeded and the other failed."
-

--- a/z_appliance_control_center/ssa_deploy_ansible/02_ssa_install_e2e_standalone.yaml
+++ b/z_appliance_control_center/ssa_deploy_ansible/02_ssa_install_e2e_standalone.yaml
@@ -19,6 +19,7 @@
 # *|   - Updated task ID extraction to support both 'task-id' and           |
 # *|     'task_id' formats for backward/forward compatibility               |
 # *|   - Added automatic rollback debug messages when activation fails      |
+# *|   - Added optional HMC credential expiry support                       |
 # *+------------------------------------------------------------------------+
 
 # Tested with OSA and FCP devices, on non-DPM mode machine.
@@ -821,6 +822,13 @@
             | map(attribute='json.lpar')
             | list
           }}
+        acc_failed_task_details: >-
+          {{
+            poll_status.results
+            | selectattr('json.action-status', 'match', '(?i)fail|error')
+            | map(attribute='json')
+            | list
+          }}
 
     - name: Debug message - Automatic rollback information
       ansible.builtin.debug:
@@ -831,6 +839,11 @@
           Failed Task IDs: {{ acc_failed_tasks }}
 
           NOTE: ACC is handling the rollback of LPAR(s) {{ acc_failed_lpars | join(', ') }} in the background.
+      when: acc_failed_tasks | length > 0
+
+    - name: "FAILED - Task Details"
+      ansible.builtin.debug:
+        var: acc_failed_task_details
       when: acc_failed_tasks | length > 0
 
     - name: Fail play if any task failed

--- a/z_appliance_control_center/ssa_deploy_ansible/03_acc_ssa_install_check.yaml
+++ b/z_appliance_control_center/ssa_deploy_ansible/03_acc_ssa_install_check.yaml
@@ -11,6 +11,9 @@
 # *|   - acc_ip extracted from acc_url automatically                        |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC playbook, run as ACC-admin, to get sanity check of ACC and SSAs install
@@ -63,7 +66,7 @@
     - name: Extract IP from URL
       ansible.builtin.set_fact:
         acc_ip: "{{ acc_url | urlsplit('hostname') }}"
-        
+
     - name: 00 - Check if ACC appliance is operational
       ansible.builtin.uri:
         url: "https://{{ acc_ip }}/api/com.ibm.zaci.system/appliance/is-operational"

--- a/z_appliance_control_center/ssa_deploy_ansible/04_unlock_ssa_after_hmc_install.yaml
+++ b/z_appliance_control_center/ssa_deploy_ansible/04_unlock_ssa_after_hmc_install.yaml
@@ -8,6 +8,9 @@
 # *|   - Replaced cc_url with acc_url                                       |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
+# *|   - Added execution timestamp and ACC about info display               |
 # *+------------------------------------------------------------------------+
 
 - name: ACC Playbook, run by appliance-owner, for appliance-owner actions
@@ -72,7 +75,6 @@
       default: "yes"
 
   tasks:
-
     - name: 00 - Check MFA is enabled or not
       ansible.builtin.pause:
         prompt: "Do you have MFA enabled? (yes/no):"
@@ -198,6 +200,10 @@
       tags: owner, install
       ansible.builtin.set_fact:
         access_token: "{{ auth_response.json.access_token }}"
+
+    - name: Display execution info and ACC about information
+      ansible.builtin.include_tasks:
+        file: ../other_usecases_ansible/common_display_info.yaml
 
     - name: 07 - Get list of active SSAs
       ansible.builtin.uri:

--- a/z_appliance_control_center/ssa_deploy_ansible/README.md
+++ b/z_appliance_control_center/ssa_deploy_ansible/README.md
@@ -73,6 +73,12 @@ mode of ACC, where ACC can communicate with the HMC.
   export HMC_PASSWORD=<enter_HMC_password>
   ```
 
+  **Optional:** During playbook execution, you will be prompted to set an HMC credential
+  expiry time. Enter a number between 1-14 to set credentials to expire after that many
+  days. On leaving empty we do not pass credential expiry time and hence ACC takes the
+  default expiry of 1 day. This enhances security by ensuring credentials are refreshed
+  regularly.
+
 - Export the previously set default appliance-owner password and additionally set and export
   a new password for the appliance-owner. Keep in mind, the ACC API will be used to set the
   new password for appliance-owner. Therefore, be sure you are following the password

--- a/z_appliance_control_center/ssa_deploy_ansible/README.md
+++ b/z_appliance_control_center/ssa_deploy_ansible/README.md
@@ -21,6 +21,10 @@ playbooks `01_admin_actions.yaml`, `02b_assign_2_lpar.yaml`,
 If you have a clear separation of roles in your organization, it is better to
 use the playbooks in the `appliance_deploy_*` directories.
 
+### Features
+
+- **Execution Timestamp and ACC About Info Display**: All playbooks (`01_ssa_install_e2e_default.yaml`, `02_ssa_install_e2e_standalone.yaml`, `04_unlock_ssa_after_hmc_install.yaml`) now display execution timestamp and ACC about information at the start of execution for better tracking and debugging.
+
 ## SSA Installation (Default Mode) | 01_ssa_install_e2e_default.yaml
 
 To install 2x SSAs after a fresh install of ACC, you can run this playbook.

--- a/z_appliance_control_center/ssa_deploy_ansible/env_vars.yaml
+++ b/z_appliance_control_center/ssa_deploy_ansible/env_vars.yaml
@@ -7,6 +7,8 @@
 # *|   - Tested with ACC 1.2.12                                             |
 # *| [04.02.2026]                                                           |
 # *|   - Tested with ACC 1.2.13                                             |
+# *| [06.26.2026]                                                           |
+# *|   - Tested with ACC 1.2.14                                             |
 # *+------------------------------------------------------------------------+
 
 #####################################################################################################
@@ -30,7 +32,6 @@ mfa_enabled: false
 
 # IP of the ACC LPAR (e.g., "https://9.152.150.224:8081/api")
 acc_url: https://9.120.0.0:8081/api
-
 
 ####### HMC #######
 
@@ -92,13 +93,13 @@ image_type: "image"
 # specific set of logical partition (LPAR) and an appliance owner on an IBM Z system.
 # The resource package defines how many total number of Cores (GPs or IFLs),
 # how much total memory, and which LPARs within a CPC are assigned to the appliance owner.
-# The parameters below define the resource package to be created and assigned. When installing  
+# The parameters below define the resource package to be created and assigned. When installing
 # two SSAs, ensure that the resource package includes sufficient resources (ifls/gps and memory)
 # to accommodate both SSA LPARs. The allocations defined later in the Install section below
 # for the SSA appliances will be drawn from the total resources specified in the resource package.
 # ------------------------------------------------------------------------------
 #
-# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR. 
+# The SSA appliance requires at least 2 IFLs and a minimum of 51200 (in MB) per LPAR.
 # For better performance, more resource can be assigned depending on the expected workload.
 #
 # Memory should always be a multiple of 1024 (1 GB).
@@ -148,7 +149,7 @@ chpid1: "xx"
 zport1: 0
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk1_id: "0.0.5abc"
 
@@ -179,7 +180,7 @@ gw1_ip: "9.102.0.1"
 # Secure Service Container graphical user interface (GUI). An administrator user ID can
 # be 1 - 32 characters long. It cannot contain blanks. Valid characters are numbers
 # 0 - 9, letters A - Z (upper or lower case), and the following special
-# characters: period (.), underscore (_), and hyphen (-). 
+# characters: period (.), underscore (_), and hyphen (-).
 # SSA1_APP_PASSWORD: This is the Administrator password in the SSC user guide.
 # This password can have a minimum of 8 characters and a maximum of 256 characters.
 # An administrator password is case-sensitive and can contain numbers 0 - 9, letters A - Z
@@ -219,7 +220,7 @@ chpid2: "xx"
 zport2: 0
 
 # Disk identifier (e.g., "5f20" start with 0.0) for installing image on lpar disk
-# Note: When using FCP this variable represents the LPAR's FCP device number used to 
+# Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
 disk2_id: "0.0.5abc"
 
@@ -250,7 +251,7 @@ gw2_ip: "9.102.0.1"
 # Secure Service Container graphical user interface (GUI). An administrator user ID can
 # be 1 - 32 characters long. It cannot contain blanks. Valid characters are numbers
 # 0 - 9, letters A - Z (upper or lower case), and the following special
-# characters: period (.), underscore (_), and hyphen (-). 
+# characters: period (.), underscore (_), and hyphen (-).
 # SSA2_APP_PASSWORD: This is the Administrator password in the SSC user guide.
 # This password can have a minimum of 8 characters and a maximum of 256 characters.
 # An administrator password is case-sensitive and can contain numbers 0 - 9, letters A - Z
@@ -267,7 +268,7 @@ lpar2_admin_user: "{{ lookup('env', 'SSA2_APP_USERNAME') }}"
 lpar2_admin_password: "{{ lookup('env', 'SSA2_APP_PASSWORD') }}"
 
 ################################################################################
-# From the HMC, select the LPAR you’re working with. In the Tasks panel, 
+# From the HMC, select the LPAR you’re working with. In the Tasks panel,
 # open the Operational Customization drop-down, choose Customize/Delete Activation Profiles,
 # and navigate to the Processor section, check the processor type and value:
 # - Dedicated central processors
@@ -281,7 +282,7 @@ lpar2_admin_password: "{{ lookup('env', 'SSA2_APP_PASSWORD') }}"
 # otherwise set it to "general-purpose" for central processors
 # Set processor_type for the LPAR (used during image installation)
 # Keep in mind, the processor type defined here correlates to the min_ifl value defined below.
-#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance. 
+#   - For example, if min_ifls is set to 2 and processor_type is "ifl", then 2 IFLs will be assigned as the minimum for the appliance.
 #     If min_ifls is set to 2 and processor_type is "general-purpose", then 2 gps will be assigned as the minimum for the appliance.
 
 processor_type: "general-purpose"
@@ -306,8 +307,8 @@ install: true
 
 # **********************************************************************************************
 # Keep in mind when two SSA appliances are being installed, the cores and memory defined here
-# will be applied to each appliance LPAR individually. 
-# 
+# will be applied to each appliance LPAR individually.
+#
 # Always ensure that the resource package defined earlier above provides sufficient capacity
 # to support the appliances being installed.
 # **********************************************************************************************


### PR DESCRIPTION
Comprehensive changes for z Appliance Control Center (ACC) version 1.2.14, including new features, and new playbooks.

## Key Features

### Configuration Management

- Export/Import: Full ACC configuration backup and restore
- Metadata tracking: Timestamps and descriptions
- Post-import automation: Reboot, operational checks, post-process updates

### Enhanced Monitoring

- Task management: Query task status by ID
- Log gathering: Pull SSC and ACC logs
- About information: Version and system info display
- Execution tracking: Timestamp and run information

## Major Changes

In `acc_install_ansible/`, included a fix for token expiry. 

---

Other changes in the `other_usecases_ansible/` directory for config management & monitoring: 

### `14_acc_export_config.yaml` - Export ACC configuration

- Binary export with metadata
- Timestamp-based filenames
- Important disclaimer about images not being retained


### `15_acc_restore_config.yaml` - Restore ACC configuration

- Binary import with apply_now option
- Post-import reboot and operational checks
- Re-authentication after restart
- Post-process appliance update workflow


### `16_get_task_info.yaml` - Query task status by ID

- Interactive task ID input
- Task status retrieval and display

### `17_tasks_pull_ssc_logs.yaml` - Pull SSC logs via tasks API

### `18_gather_acc_logs.yaml` - Gather ACC system logs

### `19_acc_about_info.yaml` - Get ACC version and about information

- Supports both admin and owner users
- MFA support with OTP input

### `20_get_preserved_appliance_info.yaml` - Get preserved appliance information

### `common_display_execution_info.yaml` - Reusable execution info display

- Shows run date, time, timezone, ISO8601 timestamp

### `common_display_info.yaml` - Combined execution + ACC about info

- Includes common_display_execution_info.yaml
- Fetches and displays ACC about information
- Graceful handling for older ACC versions

### `export_import_vars.yaml` - Variables for export/import operations

- Export directory configuration
- LPAR name specification

---

In `appliance_deploy_*_ansible/` folders, here are the major changes:

### `01_admin_actions.yaml` - Added HMC credential expiry information

### `04_install_flow.yaml` - Improved install experience and debug messages

### `owner_vars.yaml` - Added info about fast activate and image_match_check variable