### PR TITLE
[WIP] ACC 1.2.15 Fixes

### DIFF
--- a/z_appliance_control_center/README.md
+++ b/z_appliance_control_center/README.md
@@ -187,6 +187,16 @@ credentials are stored in ACC as an encrypted memory buffer, which is flushed
 every 24 hours. Therefore, ACC-admin must again provide these credentials to
 the ACC.
 
+**HMC Credential Expiry (ACC 1.2.14+)**: Starting from ACC version 1.2.14, the ACC-admin can optionally configure an expiry period for HMC credentials when inserting them into ACC. This allows the credentials to be automatically cleared after a specified number of days (1-14 days), providing enhanced security control. The ACC-admin can:
+
+- Set the expiry period using the `days_to_clear_hmc_creds` parameter when calling the `/api/config/hmcconfig` endpoint
+- Check the credential validity and expiry time using the `/api/about` endpoint, which returns:
+  - `hmc_credential_validity_days`: Number of days remaining until credentials expire
+  - `hmc_credential_clears_at`: Timestamp when credentials will be cleared
+- Use the playbooks `07_insert_hmc_creds.yaml` the `other_usecases_ansible` directory to manage HMC credentials with expiry
+
+If no expiry is set, the default behavior of clearing credentials every 24 hours remains unchanged.
+
 #### ACC-Admin and Appliance-Owner Credentials
 
 The default ACC-admin credentials correspond to the ACC LPAR credentials. These default credentials must be updated using the [update password](https://www.ibm.com/docs/en/systems-hardware/zsystems/9175-ME1?topic=reference-user-management#api_reference__title__3) ACC API endpoint. These credentials must be updated before issuing any other ACC API requests.
@@ -262,6 +272,7 @@ use-cases for:
 - Pulling SSA logs and Checking health status of SSA
 - Syncing LPARs
 - Install checks for ACC and SSA
+- Exporting and restoring ACC configuration
 
 Please read the `README.md` file in the appropriate playbook directory before proceeding.
 
@@ -313,12 +324,14 @@ This directory is used for other use cases associated with ACC and appliances.
 
 | File | Purpose |
 |:---------|:--------|
-| `env_vars.yaml` | This file contains variables used by the environment, e.g., to install 2x SSAs |
 | `owner_vars.yaml` | This file contains variables used by the appliance owners regarding their appliances |
-| `acc_ssa_install_check_vars.yaml` | This file contains variables used for checking ACC and 2x SSA installations |
-| `00_resource_scan.yaml`| Appliance owner can use this playbook to gather information about the resources assigned and consumed by the owner |
+| `admin_vars.yaml` | This file contains variables used by the ACC administrator |
+| `export_import_vars.yaml` | This file contains variables used by the export and restore configuration playbooks (e.g., `export_dir`) |
+| `common_display_info.yaml` | Shared tasks file that displays playbook execution timestamp and ACC about information; included by multiple playbooks |
+| `common_display_execution_info.yaml` | Shared tasks file that displays playbook execution timestamp only; included by `common_display_info.yaml` |
+| `00_resource_scan.yaml` | Appliance owner can use this playbook to gather information about the resources assigned and consumed by the owner |
 | `01_upgrade_flow.yaml` | Appliance owner can use this playbook to upgrade an appliance, which will format the disk and install a new appliance |
-| `02_sync_cpc_lpars.yaml` | ACC administrator can use this playbook to sync the state of the CPCs on the HMC, and LPARs. |
+| `02_sync_cpc_lpars.yaml` | ACC administrator can use this playbook to sync the state of the CPCs on the HMC, and LPARs |
 | `03_pull_ssc_logs.yaml` | ACC administrator can use this playbook to pull logs out of an SSC appliance like ACC |
 | `04_managed_appliance_update.yaml` | Appliance owner can use this playbook to update currently running appliances |
 | `05_managed_appliance_health_and_pull_logs.yaml` | Appliance owner can use this playbook to gather health status of the appliances and pull their logs |
@@ -327,9 +340,17 @@ This directory is used for other use cases associated with ACC and appliances.
 | `08_restart_acc.yaml` | ACC administrator can use this playbook to restart ACC |
 | `09_get_disruptive_dumps.yaml` | This playbook can be used by the ACC administrator to pull disruptive dumps/logs out of the appliances |
 | `10_unlock_appliances.yaml` | This playbook can be used by the appliance owners to unlock their appliances |
-| `11_unlock_each_appliances.yaml` | This playbook can be used in conjunction with `10_unlock_appliances.yaml` |
+| `11_unlock_each_appliance.yaml` | This playbook can be used in conjunction with `10_unlock_appliances.yaml` to unlock each appliance individually |
 | `12_logout_owner.yaml` | The appliance-owner can use this playbook to logout of ACC |
 | `13_restart_appliances.yaml` | The appliance-owner can use this playbook to restart appliances that are managed by ACC |
+| `14_acc_export_config.yaml` | ACC administrator can use this playbook to export ACC configuration to a file for backup or migration purposes |
+| `15_acc_restore_config.yaml` | ACC administrator can use this playbook to restore a previously exported ACC configuration |
+| `16_get_task_info.yaml` | Appliance owner can use this playbook to query the status of a specific task by its ID |
+| `17_tasks_pull_ssc_logs.yaml` | Shared tasks file (not run directly) for pulling SSC/appliance logs; reused by `03_pull_ssc_logs.yaml` and `18_gather_acc_logs.yaml` |
+| `18_gather_acc_logs.yaml` | Unified playbook for gathering all ACC-related logs (tasks, history, audit, about, and appliance logs) in a single execution; role-aware |
+| `19_acc_about_info.yaml` | ACC administrator or appliance owner can use this playbook to query ACC version and build information via the `/about` API |
+| `20_get_preserved_appliance_info.yaml` | Appliance owner can use this playbook to retrieve preserved information for an inactive appliance |
+| `export_data/` | Directory where exported ACC configuration files are stored (created by `14_acc_export_config.yaml`) |
 
 ## ACC Features and Limitations
 
@@ -499,7 +520,7 @@ Thats it. Ansible-lint should run and block you from commit locally if there are
 If pre-commit is previously installed and a reinstall is required:
 
 ```Linux
-pre-commit clean   
+pre-commit clean
 pre-commit uninstall
 python -m pip install --user -r requirements.txt
 ```
@@ -508,6 +529,21 @@ python -m pip install --user -r requirements.txt
 
 These playbooks are tested with different versions of ACC. Below is a
 brief change-log of these playbooks.
+
+### ACC version 1.2.15
+
+- ACC-admin can now set the hostname of the ACC LPAR via the `LPAR_HOSTNAME` variable in
+  `acc_install_ansible/acc_env_vars.yaml`. The hostname is used when generating a Certificate
+  Signing Request (CSR), allowing a Fully Qualified Domain Name (FQDN) to be specified for
+  use in the resulting certificate.
+
+### ACC version 1.2.13 to 1.2.14
+
+- All playbooks now display execution timestamp and ACC about information at the start of execution.
+- `07_insert_hmc_creds.yaml` and `01_admin_actions.yaml` (default and MFA variants) now support optional HMC credential expiry.
+- New playbooks added to `other_usecases_ansible`: `16_get_task_info.yaml`, `17_tasks_pull_ssc_logs.yaml`, `18_gather_acc_logs.yaml`, `19_acc_about_info.yaml`, `20_get_preserved_appliance_info.yaml`.
+- `03_pull_ssc_logs.yaml` refactored to use the shared `17_tasks_pull_ssc_logs.yaml` tasks file, also used by `18_gather_acc_logs.yaml`.
+- Install flow playbooks updated to handle both `task-id` and `task_id` response formats and display rollback debug messages on activation failure.
 
 ### ACC version 1.2.12 to 1.2.13
 

--- a/z_appliance_control_center/README.md
+++ b/z_appliance_control_center/README.md
@@ -193,7 +193,7 @@ the ACC.
 - Check the credential validity and expiry time using the `/api/about` endpoint, which returns:
   - `hmc_credential_validity_days`: Number of days remaining until credentials expire
   - `hmc_credential_clears_at`: Timestamp when credentials will be cleared
-- Use the playbooks `07_insert_hmc_creds.yaml` the `other_usecases_ansible` directory to manage HMC credentials with expiry
+- Use the playbooks `07_insert_hmc_creds.yaml` in the `other_usecases_ansible` directory to manage HMC credentials with expiry
 
 If no expiry is set, the default behavior of clearing credentials every 24 hours remains unchanged.
 

--- a/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
+++ b/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
@@ -57,7 +57,7 @@
     LOCAL_SSH_PORT: 9989
     VERIFY_CERT: false
     GATEWAY_USER: "fpc-gw"
-    HTTPS_PORT: 443
+    HTTPS_PORT: "443"
     SSH_PORT: 23
     D_PORT: 0
     IS_PRIVATE: false

--- a/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
+++ b/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
@@ -55,12 +55,12 @@
     LOCAL_SERVER_IP: localhost
     LOCAL_SERVER_PORT: "9988"
     LOCAL_SSH_PORT: "9989"
-    VERIFY_CERT: false
+    VERIFY_CERT: "false"
     GATEWAY_USER: "fpc-gw"
     HTTPS_PORT: "443"
     SSH_PORT: "23"
     D_PORT: "0"
-    IS_PRIVATE: false
+    IS_PRIVATE: "false"
     ANSIBLE_TMPDIR: "{{ INSTALL_SCRIPT_PATH }}"
     HMC_KEY: "~/.ssh/id_rsa"
     STORAGE: "{{ STORAGE }}"

--- a/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
+++ b/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
@@ -53,13 +53,13 @@
     ACTION: "{{ ACTION }}"
     HTTP_SCHEME: https
     LOCAL_SERVER_IP: localhost
-    LOCAL_SERVER_PORT: 9988 # ansible-lint ignore[var-naming]
-    LOCAL_SSH_PORT: 9989 # ansible-lint ignore[var-naming]
+    LOCAL_SERVER_PORT: "9988"
+    LOCAL_SSH_PORT: "9989"
     VERIFY_CERT: false
     GATEWAY_USER: "fpc-gw"
     HTTPS_PORT: "443"
-    SSH_PORT: 23 # ansible-lint ignore[var-naming]
-    D_PORT: 0 # ansible-lint ignore[var-naming]
+    SSH_PORT: "23"
+    D_PORT: "0"
     IS_PRIVATE: false
     ANSIBLE_TMPDIR: "{{ INSTALL_SCRIPT_PATH }}"
     HMC_KEY: "~/.ssh/id_rsa"

--- a/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
+++ b/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
@@ -16,6 +16,9 @@
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Added network configuration for ACC LPAR                           |
 # *|   - Added IFLs/GPs configuration for ACC LPAR                          |
+# *| [07.28.2026]                                                           |
+# *|   - Tested with ACC 1.2.15                                             |
+# *|   - Setting host name of the ACC LPAR                                  |
 # *+------------------------------------------------------------------------+
 
 # Important: Before running the 00_acc_install.yaml script, kindly review the README file located in
@@ -63,6 +66,7 @@
     STORAGE: "{{ STORAGE }}"
     IFLS: "{{ IFLS }}"
     GPS: "{{ GPS }}"
+    LPAR_HOSTNAME: "{{ LPAR_HOSTNAME }}"
 
   pre_tasks:
     - name: Reminder - Export credentials (HMC connected)

--- a/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
+++ b/z_appliance_control_center/acc_install_ansible/00_acc_install.yaml
@@ -53,13 +53,13 @@
     ACTION: "{{ ACTION }}"
     HTTP_SCHEME: https
     LOCAL_SERVER_IP: localhost
-    LOCAL_SERVER_PORT: 9988
-    LOCAL_SSH_PORT: 9989
+    LOCAL_SERVER_PORT: 9988 # ansible-lint ignore[var-naming]
+    LOCAL_SSH_PORT: 9989 # ansible-lint ignore[var-naming]
     VERIFY_CERT: false
     GATEWAY_USER: "fpc-gw"
     HTTPS_PORT: "443"
-    SSH_PORT: 23
-    D_PORT: 0
+    SSH_PORT: 23 # ansible-lint ignore[var-naming]
+    D_PORT: 0 # ansible-lint ignore[var-naming]
     IS_PRIVATE: false
     ANSIBLE_TMPDIR: "{{ INSTALL_SCRIPT_PATH }}"
     HMC_KEY: "~/.ssh/id_rsa"

--- a/z_appliance_control_center/acc_install_ansible/README.md
+++ b/z_appliance_control_center/acc_install_ansible/README.md
@@ -195,6 +195,15 @@ To set up the ACC, the following actions must be performed by the ACC-admin.
       an error.
     - Note that the IFLs or GPs on the ACC LPAR are shared, and they
       use an initial processing weight of `10`.
+  - Optionally, set the `LPAR_HOSTNAME` variable for the ACC LPAR in the `acc_env_vars.yaml`
+    - If setting a custom `LPAR_HOSTNAME`, the value must meet the following requirements:
+      - 1–64 characters in length
+      - Valid characters: letters (a–z, A–Z), digits (0–9), periods (`.`), and hyphens (`-`)
+      - No consecutive periods (`..`)
+      - No leading or trailing periods (`.`)
+    - To use the default hostname (`acchost`), either leave `LPAR_HOSTNAME` as an empty
+      string `""` or do not set it.
+
 - Run the following playbook to install ACC:
   ```bash
   ansible-playbook ./acc_install_ansible/00_acc_install.yaml
@@ -234,6 +243,7 @@ reference):
 - `ssc-master-pw`
 - `ssc-gateway-info`
 - `ssc-network-info`
+- `ssc-host-name`
 
 Therefore, it is possible that old settings on the LPAR are still
 intact after running these scripts. Therefore, the caller must take

--- a/z_appliance_control_center/acc_install_ansible/acc_env_vars.yaml
+++ b/z_appliance_control_center/acc_install_ansible/acc_env_vars.yaml
@@ -11,6 +11,9 @@
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Added network configuration for ACC LPAR                           |
 # *|   - Added IFLs/GPs configuration for ACC LPAR                          |
+# *| [07.28.2026]                                                           |
+# *|   - Tested with ACC 1.2.15                                             |
+# *|   - Setting host name of the ACC LPAR                                  |
 # *+------------------------------------------------------------------------+
 
 # Variables used for installing ACC
@@ -94,6 +97,13 @@ LPAR: "CC12"
 # activation profile of the LPAR
 LPAR_IP: "9.x.x.x"
 
+# Hostname for the ACC LPAR (e.g., "zfwssc16.de.ibm.com")
+# To use the default hostname (acchost), either leave LPAR_HOSTNAME as an empty string "" or do not set it
+# If set, then the value must meet the following requirements:
+#  - must be 1-64 characters using only: a-z, A-Z, 0-9, period (.), hyphen (-),
+#  - no consecutive period(.), no trailing/leading period(.)
+LPAR_HOSTNAME: ""
+
 # Disk identifier (e.g., "5f47" start with 0.0) for installing image on lpar disk
 # Note: When using FCP this variable represents the LPAR's FCP device number used to
 # communicate with the boot volume on the storage controller
@@ -141,7 +151,7 @@ NW_CHPID: "d0"
 NW_PORT: 0
 
 # Prefix
-NW_PREFIX: 24
+NW_PREFIX: 23
 
 # VLAN ID
 # If not used, then NW_VLANID variable empty ""

--- a/z_appliance_control_center/acc_install_ansible/activate_deactivate.py
+++ b/z_appliance_control_center/acc_install_ansible/activate_deactivate.py
@@ -11,6 +11,9 @@
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Added network configuration for ACC LPAR                           |
 # *|   - Added IFLs/GPs configuration for ACC LPAR                          |
+# *| [07.28.2026]                                                           |
+# *|   - Tested with ACC 1.2.15                                             |
+# *|   - Setting host name of the ACC LPAR                                  |
 # *+------------------------------------------------------------------------+
 
 import sys
@@ -169,6 +172,9 @@ def set_image_activation_profile(cpc, profile_name: str):
         'ssc-gateway-info': gw_ip_info,
         'ssc-network-info': ssc_nw
     }
+    # Set hostname only if provided; omitting it leaves the existing HMC value unchanged
+    hostname = os.environ.get("LPAR_HOSTNAME") or "acchost"
+    properties['ssc-host-name'] = hostname
     
     # Add storage if specified
     if storage > 0:

--- a/z_appliance_control_center/acc_install_ansible/dpm_operations.py
+++ b/z_appliance_control_center/acc_install_ansible/dpm_operations.py
@@ -11,6 +11,9 @@
 # *|   - Tested with ACC 1.2.13                                             |
 # *|   - Added network configuration for ACC LPAR                           |
 # *|   - Added IFLs/GPs configuration for ACC LPAR                          |
+# *| [07.28.2026]                                                           |
+# *|   - Tested with ACC 1.2.15                                             |
+# *|   - Setting host name of the ACC LPAR                                  |
 # *+------------------------------------------------------------------------+
 
 import sys
@@ -161,7 +164,8 @@ def update_partition_properties(cpc, lpar_name: str):
     user = os.environ.get("USERNAME")
     password = os.environ.get("PASSWORD")
     gw_ip = os.environ.get("NW_GW_IP")
-    properties = { "ssc-host-name" : "acchost",
+    hostname = os.environ.get("LPAR_HOSTNAME") or "acchost"
+    properties = { "ssc-host-name" : hostname,
                                 'ssc-boot-selection': 'installer',
                                 'initial-memory': storage,
                                 'ssc-master-userid':user,

--- a/z_appliance_control_center/aioptimizer4z_install_ansible/env_vars_aiopt.yaml
+++ b/z_appliance_control_center/aioptimizer4z_install_ansible/env_vars_aiopt.yaml
@@ -8,7 +8,7 @@
 #####################################################################################################
 # NOTE: If you uncomment any variables in the vars file, be sure to uncomment the corresponding
 # sections that reference those variables in the scripts. Please review the script thoroughly before execution.
-# 
+#
 # Do not comment out any variables in this file as it may trigger a playbook failure. If a variable is not applicable it
 # can be safley ignored.
 ######################################################################################################

--- a/z_appliance_control_center/appliance_deploy_default_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_ansible/04_install_flow.yaml
@@ -171,12 +171,12 @@
                   {
                     "name": "{{ lpar1_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": {{ install }}
+                    "install": {{ install | lower }}
                   },
                   {
                     "name": "{{ lpar2_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": {{ install }}
+                    "install": {{ install | lower }}
                   }
                 ]
               }

--- a/z_appliance_control_center/appliance_deploy_default_mfa_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_default_mfa_ansible/04_install_flow.yaml
@@ -185,12 +185,12 @@
                   {
                     "name": "{{ lpar1_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install | lower }}
                   },
                   {
                     "name": "{{ lpar2_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install | lower }}
                   }
                 ]
               }

--- a/z_appliance_control_center/appliance_deploy_standalone_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_ansible/04_install_flow.yaml
@@ -216,12 +216,12 @@
                   {
                     "name": "{{ lpar1_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install | lower }}
                   },
                   {
                     "name": "{{ lpar2_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install | lower }}
                   }
                 ]
               }

--- a/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/04_install_flow.yaml
+++ b/z_appliance_control_center/appliance_deploy_standalone_mfa_ansible/04_install_flow.yaml
@@ -221,12 +221,12 @@
                   {
                     "name": "{{ lpar1_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install | lower }}
                   },
                   {
                     "name": "{{ lpar2_name }}",
                     "execution_action": "{{ execution_action }}",
-                    "install": "{{ install }}"
+                    "install": {{ install | lower }}
                   }
                 ]
               }

--- a/z_appliance_control_center/other_usecases_ansible/03_pull_ssc_logs.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/03_pull_ssc_logs.yaml
@@ -33,9 +33,6 @@
       prompt: "Enter reason to create logs"
       private: false
 
-  vars:
-    log_destination: "/tmp/ssc_{{ '%Y-%m-%d_%H:%M:%S' | strftime }}.gz"
-
   tasks:
     - name: Display playbook execution information
       ansible.builtin.include_tasks:

--- a/z_appliance_control_center/other_usecases_ansible/04_managed_appliance_update.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/04_managed_appliance_update.yaml
@@ -258,9 +258,9 @@
             Status: {{ 'Locked' if app.is_locked else 'Unlocked' }}
           {% endfor %}
 
-    - name: 09 - Unlock appliances one by one
+    - name: "09 - Unlock the target appliance (lpar_name: {{ lpar_name }})"
       ansible.builtin.include_tasks: 11_unlock_each_appliance.yaml
-      loop: "{{ quotas_response.json }}"
+      loop: "{{ quotas_response.json | selectattr('name', 'equalto', lpar_name) | list }}"
       loop_control:
         loop_var: appliance
 

--- a/z_appliance_control_center/other_usecases_ansible/06_acc_appliance_update.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/06_acc_appliance_update.yaml
@@ -419,6 +419,11 @@
               until: is_operational_response.status in [204]
               when: reboot_value
 
+            - name: Wait for API to finish initialising after reboot
+              ansible.builtin.wait_for:
+                timeout: 30
+              when: reboot_value
+
             - name: Fetch authentication token from the ACC after reboot
               ansible.builtin.uri:
                 url: "{{ appliance_url }}/api-tokens"
@@ -435,7 +440,13 @@
                 body_format: json
                 return_content: true
                 validate_certs: false
+                status_code: 200
               register: auth_response
+              retries: 3
+              delay: 15
+              until: auth_response.status == 200
+              failed_when: false
+              when: reboot_value
 
             - name: Extract the token from response
               ansible.builtin.set_fact:

--- a/z_appliance_control_center/other_usecases_ansible/08_restart_acc.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/08_restart_acc.yaml
@@ -180,9 +180,37 @@
           - 204
       register: is_operational_response
       until: is_operational_response.status in [202, 204]
+
+    - name: Wait for API to finish initialising after reboot
+      ansible.builtin.wait_for:
+        timeout: 30
+
+    - name: Fetch authentication token from the ACC after reboot
+      ansible.builtin.uri:
+        url: "{{ api_base_url }}/api-tokens"
+        method: POST
+        headers:
+          zACI-API: "com.ibm.zaci.system/1.0"
+          Accept: "application/vnd.ibm.zaci.payload+json"
+          Content-Type: "application/vnd.ibm.zaci.payload+json;version=1.0"
+        body:
+          kind: "request"
+          parameters:
+            user: "{{ lpar_username }}"
+            password: "{{ lpar_password }}"
+        body_format: json
+        return_content: true
+        validate_certs: false
+        status_code: 200
+      register: auth_response
       retries: 10
-      delay: 5
+      delay: 15
+      until: auth_response.status == 200
       failed_when: false
+
+    - name: Extract the token from response after reboot
+      ansible.builtin.set_fact:
+        access_token: "{{ auth_response.json.parameters.token }}"
 
     - name: Display appliance status
       ansible.builtin.debug:

--- a/z_appliance_control_center/other_usecases_ansible/09_get_disruptive_dumps.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/09_get_disruptive_dumps.yaml
@@ -136,6 +136,11 @@
           failed_when: false
           ignore_errors: true
 
+
+        - name: Wait for API to finish initialising after reboot
+          ansible.builtin.wait_for:
+            timeout: 30
+
         - name: Fetch authentication token from the ACC after reboot
           ansible.builtin.uri:
             url: "{{ api_base_url }}/api-tokens"
@@ -152,7 +157,12 @@
             body_format: json
             return_content: true
             validate_certs: false
+            status_code: 200
           register: auth_response
+          retries: 10
+          delay: 15
+          until: auth_response.status == 200
+          failed_when: false
 
         - name: Extract the token from response
           ansible.builtin.set_fact:

--- a/z_appliance_control_center/other_usecases_ansible/15_acc_restore_config.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/15_acc_restore_config.yaml
@@ -174,6 +174,10 @@
       ansible.builtin.debug:
         msg: "ACC appliance is operational after configuration restore"
 
+    - name: Wait for API to finish initialising after reboot
+      ansible.builtin.wait_for:
+        timeout: 30
+
     # ---------------------------------------------------------------------
     # Re-authenticate after restart
     # ---------------------------------------------------------------------
@@ -193,7 +197,12 @@
         body_format: json
         return_content: true
         validate_certs: false
+        status_code: 200
       register: post_reboot_auth
+      retries: 10
+      delay: 15
+      until: post_reboot_auth.status == 200
+      failed_when: false
 
     - name: Update access token after reboot
       ansible.builtin.set_fact:

--- a/z_appliance_control_center/other_usecases_ansible/17_tasks_pull_ssc_logs.yaml
+++ b/z_appliance_control_center/other_usecases_ansible/17_tasks_pull_ssc_logs.yaml
@@ -118,5 +118,15 @@
     validate_certs: false
     status_code: 200
     timeout: 180
-    dest: "{{ log_destination }}"
+    dest: "/tmp/ssc_temp_{{ alert_uuid }}.gz"
   register: ssc_download_result
+
+- name: Set final log destination with current timestamp
+  when: log_destination is not defined
+  ansible.builtin.set_fact:
+    log_destination: "/tmp/ssc_{{ '%Y-%m-%d_%H:%M:%S' | strftime }}.gz"
+
+- name: Move temp file to final destination with timestamp
+  ansible.builtin.command:
+    cmd: "mv /tmp/ssc_temp_{{ alert_uuid }}.gz {{ log_destination }}"
+  changed_when: true

--- a/z_appliance_control_center/other_usecases_ansible/README.md
+++ b/z_appliance_control_center/other_usecases_ansible/README.md
@@ -552,33 +552,36 @@ To get task information:
 
 The playbook prints the full status response returned by the ACC `/tasks/{id}/status` API.
 
-## Get Preserved Appliance Information | 20_get_preserved_appliance_info.yaml
+## Pull SSC Appliance Logs | 17_tasks_pull_ssc_logs.yaml
 
-This playbook allows the appliance-owner to retrieve preserved information for inactive appliances. It is useful when an appliance is no longer active but its configuration or state data needs to be inspected.
+This is a **shared tasks file**, not a standalone playbook — it is not meant to be run directly with `ansible-playbook`. It is included by the following playbooks to handle SSC/appliance log collection:
 
-The playbook supports:
-- Fetching preserved information for a **single named resource package** or for **all resource packages**
-- Optionally filtering by specific LPAR names within the resource package(s)
+- `03_pull_ssc_logs.yaml` — pulls logs from a single named SSC appliance
+- `18_gather_acc_logs.yaml` — calls this file as part of a broader, role-aware log collection
 
-To get preserved appliance information:
+By centralizing the log-pull logic here, both callers share a single implementation, making bug fixes and behavior changes apply consistently across both playbooks.
 
-- Export the appliance-owner password on your control node:
-  ```bash
-  export ACC_OWNER_PASSWORD=<owner_password>
-  ```
-- Run the playbook:
-  ```bash
-  ansible-playbook 20_get_preserved_appliance_info.yaml
-  ```
-- The playbook will prompt for:
-  - Resource package name (or `all` to query all packages — default: `all`)
-  - MFA status (yes/no)
-  - OTP (if MFA is enabled)
-  - Whether to filter by specific LPARs (yes/no)
-  - LPAR names (comma-separated, if filtering is selected)
+### What it does
 
-The playbook prints the full preserved information response from the ACC `/cluster/inactive-appliance/preserved-info` API.
+Given a target SSC appliance, the tasks file:
 
+1. Authenticates against the SSC LPAR API and extracts a bearer token
+2. Sends a `POST /alerts` request with `diag_info: concurrent` to trigger diagnostic log creation
+3. Polls `GET /alerts/{uuid}` until the alert is handled (up to 60 retries, 10 s apart)
+4. Downloads the resulting diagnostic archive via `GET /alerts/{uuid}/diag-info` to a temporary path
+5. Moves the archive to the caller-supplied `log_destination` path (timestamped `.gz` file)
+
+### Expected variables
+
+The following variables must be set by the calling playbook before including this tasks file:
+
+| Variable | Description |
+|---|---|
+| `ssc_ip` | IP address of the SSC LPAR |
+| `lpar_username` | SSC LPAR username |
+| `lpar_password` | SSC LPAR password |
+| `reason` | Reason string embedded in the alert request |
+| `log_destination` | Full destination path for the downloaded log archive (e.g., `/tmp/ssc_2026-07-28_12:00:00.gz`) |
 
 ## Gather Comprehensive ACC Logs | 18_gather_acc_logs.yaml
 
@@ -711,3 +714,29 @@ To get ACC about information:
 
 The playbook prints the full response returned by the ACC `/about` API.
 
+## Get Preserved Appliance Information | 20_get_preserved_appliance_info.yaml
+
+This playbook allows the appliance-owner to retrieve preserved information for inactive appliances. It is useful when an appliance is no longer active but its configuration or state data needs to be inspected.
+
+The playbook supports:
+- Fetching preserved information for a **single named resource package** or for **all resource packages**
+- Optionally filtering by specific LPAR names within the resource package(s)
+
+To get preserved appliance information:
+
+- Export the appliance-owner password on your control node:
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_password>
+  ```
+- Run the playbook:
+  ```bash
+  ansible-playbook 20_get_preserved_appliance_info.yaml
+  ```
+- The playbook will prompt for:
+  - Resource package name (or `all` to query all packages — default: `all`)
+  - MFA status (yes/no)
+  - OTP (if MFA is enabled)
+  - Whether to filter by specific LPARs (yes/no)
+  - LPAR names (comma-separated, if filtering is selected)
+
+The playbook prints the full preserved information response from the ACC `/cluster/inactive-appliance/preserved-info` API.

--- a/z_appliance_control_center/other_usecases_ansible/README.md
+++ b/z_appliance_control_center/other_usecases_ansible/README.md
@@ -61,8 +61,9 @@ owner's `mfa_secret`s.
   ```
 - `cd` to the directory `other_usecases_ansible`.
 - Modify the variables in the file `owner_vars.yaml`.
-  - Change the `acc_ip` in the `owner_vars.yaml` file to point to the right
-    IP address. Change this IP and port to the one that should be serving ACC APIs.
+  - Change the `acc_url` in the `owner_vars.yaml` file to point to the right
+    IP address and port. Change this to the URL that should be serving ACC APIs
+    (e.g., `https://9.111.155.222:8081/api`).
 
 ## Updating the Appliances - 01_upgrade_flow.yaml | 04_managed_appliance_update.yaml
 
@@ -531,6 +532,53 @@ To restore ACC configuration:
   - Full path to the exported configuration file
 
 The playbook will display the import file metadata and pause for 10 seconds before proceeding with the import, giving you time to verify the correct file is being used.
+
+## Get Task Information | 16_get_task_info.yaml
+
+This playbook allows the appliance-owner to query the status of a specific ACC task by its ID.
+
+To get task information:
+
+- Export the appliance-owner password on your control node:
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_password>
+  ```
+- Run the playbook:
+  ```bash
+  ansible-playbook 16_get_task_info.yaml
+  ```
+- The playbook will prompt for:
+  - The task ID (integer) to query
+
+The playbook prints the full status response returned by the ACC `/tasks/{id}/status` API.
+
+## Get Preserved Appliance Information | 20_get_preserved_appliance_info.yaml
+
+This playbook allows the appliance-owner to retrieve preserved information for inactive appliances. It is useful when an appliance is no longer active but its configuration or state data needs to be inspected.
+
+The playbook supports:
+- Fetching preserved information for a **single named resource package** or for **all resource packages**
+- Optionally filtering by specific LPAR names within the resource package(s)
+
+To get preserved appliance information:
+
+- Export the appliance-owner password on your control node:
+  ```bash
+  export ACC_OWNER_PASSWORD=<owner_password>
+  ```
+- Run the playbook:
+  ```bash
+  ansible-playbook 20_get_preserved_appliance_info.yaml
+  ```
+- The playbook will prompt for:
+  - Resource package name (or `all` to query all packages — default: `all`)
+  - MFA status (yes/no)
+  - OTP (if MFA is enabled)
+  - Whether to filter by specific LPARs (yes/no)
+  - LPAR names (comma-separated, if filtering is selected)
+
+The playbook prints the full preserved information response from the ACC `/cluster/inactive-appliance/preserved-info` API.
+
 
 ## Gather Comprehensive ACC Logs | 18_gather_acc_logs.yaml
 

--- a/z_appliance_control_center/steps.txt
+++ b/z_appliance_control_center/steps.txt
@@ -1,0 +1,7 @@
+git checkout main
+git fetch upstream
+git pull upstream main
+git push origin main
+git checkout acc
+git merge main
+git push -u origin acc


### PR DESCRIPTION
# Documentation 

`README.md` + `other_usecases_ansible/README.md`

- New ACC 1.2.15 versioning entry (`LPAR_HOSTNAME` / FQDN for CSR)
- New ACC 1.2.13–1.2.14 versioning entry (timestamp display, HMC credential expiry, playbooks 16–20, refactored log-pull, dual task-id format fix)
- New HMC Credential Expiry section with API field documentation
- Updated `other_usecases_ansible` file reference table (corrected old entries, added rows for playbooks 14–20 and `export_data/`)
- Updated `acc_ip` → `acc_url` in owner setup instructions
- New usage sections for `16_get_task_info.yaml` and `20_get_preserved_appliance_info.yaml`

# ACC install flow — `LPAR_HOSTANAME` fix

`00_acc_install.yaml` + `acc_env_vars.yaml` + `activate_deactivate.py` + `dpm_operations.py`

- `dpm_operations.py` and `activate_deactivate.py` now read `LPAR_HOSTNAME` from the environment instead of hardcoding "acchost" — consistent across both DPM and classic-mode paths
- `acc_env_vars.yaml` gained the `LPAR_HOSTNAME` variable (with validation rules in comments)
- `00_acc_install.yaml` passes `LPAR_HOSTNAME` into the Python environment block

# Appliance Install flow — `| lower` fix

`04_install_flow.yaml` ×4, `01_ssa_install_e2e_default.yaml`, `02_ssa_install_e2e_standalone.yaml`

- "install": {{ install }} → {{ install | lower }} to ensure a valid lowercase JSON boolean reaches the ACC API

# Post-reboot auth & token handling

`06`, `08`, `09`, `15` in `other_usecases_ansible/`

- Added 30 s wait after reboot before re-authenticating; added retry loop with `status_code: 200`; increased delay in `08_restart_acc.yaml` from 5 s → 15 s

# SSC log destination refactor

`03_pull_ssc_logs.yaml` + `17_tasks_pull_ssc_logs.yaml`

Moved `log_destination` variable out of the shared tasks file into the caller, so reuse by other playbooks doesn't produce side effects

- Targeted appliance unlock

`04_managed_appliance_update.yaml`

Unlock step now filters the quota list by `lpar_name` instead of iterating all quotas