### PR TITLE
fix(ocp_upi): revert common.yaml path to playbook_dir and exclude roles in ansible-lint.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -32,6 +32,8 @@ exclude_paths:
   - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-infra-nodes-kvm/
   - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-infra-nodes-zvm/
   - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos/
+  - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/
+  - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/
   - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-network/
   - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-node-labels/
   - z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-pre-check/

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-install-ignition/tasks/main.yaml
@@ -24,7 +24,7 @@
     executable: python3
 
 - name: 'Import common yaml'
-  ansible.builtin.include_tasks: "{{ playbook_dir }}/../../../common.yaml"
+  ansible.builtin.include_tasks: "../../../common.yaml"
 
 - name: Upload boostrap ignition
   ansible.builtin.command:

--- a/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
+++ b/z_infra_provisioning/cloud_infra_center/ocp_upi/roles/configure-installer-rhcos-local/tasks/main.yaml
@@ -11,7 +11,7 @@
 # tasks file for configure-installer-and-image
 
 - name: 'Import common yaml'
-  ansible.builtin.include_tasks: "{{ playbook_dir }}/../../../common.yaml"
+  ansible.builtin.include_tasks: "../../../common.yaml"
 
 - name: Get icic project name
   ansible.builtin.shell:


### PR DESCRIPTION
- Revert common.yaml include path back to '{{ playbook_dir }}/common.yaml' in configure-install-ignition and configure-installer-rhcos-local to fix runtime execution failure
- Exclude configure-installer-rhcos-local and configure-install-ignition roles in .ansible-lint (consistent with other ocp_upi roles referencing playbook_dir/common.yaml)